### PR TITLE
feat: add tab completion for resource groups

### DIFF
--- a/azDeployGroup/azDeployGroup.sh
+++ b/azDeployGroup/azDeployGroup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # deploy-bicep.sh
-# Requirements: Azure CLI (az). Optional: fzf for a nicer RG picker.
+# Requirements: Azure CLI (az)
 
 set -euo pipefail
 
@@ -55,46 +55,30 @@ spinner_until() {
   printf "\r%-60s\r" ""  # clear line
 }
 
-pick_rg_from_list() {
-  # pick_rg_from_list "prompt" array_rgs...
-  local prompt="$1"; shift
-  local rgs=("$@")
-
-  if command -v fzf >/dev/null 2>&1; then
-    printf "%s\n" "${rgs[@]}" | fzf --prompt="${prompt} " --height=15 --reverse --border
-    return
-  fi
-
-  # fallback: tab-completion based picker using readline
-  local rg
-  __RG_LIST=("${rgs[@]}")
-  _rg_tab_complete() {
-    local cur=${READLINE_LINE:0:READLINE_POINT}
-    local matches=($(compgen -W "${__RG_LIST[*]}" -- "$cur"))
-    if (( ${#matches[@]} == 1 )); then
-      READLINE_LINE="${matches[0]}"
-      READLINE_POINT=${#READLINE_LINE}
-    elif (( ${#matches[@]} > 1 )); then
-      printf '\n%s\n' "${matches[@]}"
-      printf '%s' "${prompt} ${READLINE_LINE}"
+pick_rg_by_search() {
+  # pick_rg_by_search array_rgs...
+  local rgs=("$@") term matches rg
+  while true; do
+    read -r -p "Search resource groups (blank to list all): " term
+    if [[ -z "$term" ]]; then
+      matches=("${rgs[@]}")
+    else
+      mapfile -t matches < <(printf "%s\n" "${rgs[@]}" | grep -i -- "$term" || true)
     fi
-  }
-
-  if bind -x '"\t":_rg_tab_complete' 2>/dev/null; then
-    while true; do
-      read -e -p "${prompt} " rg
-      if printf '%s\n' "${rgs[@]}" | grep -Fxq "$rg"; then
-        bind -r '\t'
-        printf '%s' "$rg"
-        return
-      else
-        echo "Invalid resource group. Press TAB for completion."
-      fi
-    done
-  fi
-
-  # if bind failed (non-interactive shell), use numbered menu
-  select_from_list "$prompt" "${rgs[@]}"
+    if (( ${#matches[@]} == 0 )); then
+      echo "No resource groups match '$term'. Try again."
+      continue
+    fi
+    echo "Matching resource groups:"
+    printf '  %s\n' "${matches[@]}"
+    read -r -p "Resource group name: " rg
+    if printf '%s\n' "${rgs[@]}" | grep -Fxq -- "$rg"; then
+      printf '%s' "$rg"
+      return
+    else
+      echo "Resource group '$rg' not found. Try again."
+    fi
+  done
 }
 menu_pick() {
   # menu_pick "Prompt" array_items...
@@ -185,7 +169,7 @@ if [[ ! -s "$tmp_rg" ]]; then
 fi
 mapfile -t RGS < "$tmp_rg"
 
-rg_name="$(pick_rg_from_list "Resource group>" "${RGS[@]}")"
+rg_name="$(pick_rg_by_search "${RGS[@]}")"
 if [[ -z "$rg_name" ]]; then
   err "No resource group selected."
   exit 1

--- a/azDeployGroup/azDeployGroup.sh
+++ b/azDeployGroup/azDeployGroup.sh
@@ -65,41 +65,36 @@ pick_rg_from_list() {
     return
   fi
 
-  # fallback: simple "type prefix, see top 5, or exact match"
-  local input matches
-  while true; do
-    read -r -p "${prompt} (type start of name, ENTER to list top 20): " input || true
-    if [[ -z "$input" ]]; then
-      printf "%s\n" "${rgs[@]}" | head -n 20
-      continue
-    fi
-    # show up to 5 matches by prefix (case-insensitive)
-    mapfile -t matches < <(printf "%s\n" "${rgs[@]}" | grep -i "^${input}" | head -n 5 || true)
+  # fallback: tab-completion based picker using readline
+  local rg
+  __RG_LIST=("${rgs[@]}")
+  _rg_tab_complete() {
+    local cur=${READLINE_LINE:0:READLINE_POINT}
+    local matches=($(compgen -W "${__RG_LIST[*]}" -- "$cur"))
     if (( ${#matches[@]} == 1 )); then
-      echo "${matches[0]}"
-      return
+      READLINE_LINE="${matches[0]}"
+      READLINE_POINT=${#READLINE_LINE}
     elif (( ${#matches[@]} > 1 )); then
-      echo "Matches:"
-      printf "  %s\n" "${matches[@]}"
-      # let the user choose by number
-      local choice
-      read -r -p "Pick exact RG (type it) or number (1-${#matches[@]}): " choice || true
-      if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice>=1 && choice<=${#matches[@]} )); then
-        echo "${matches[$((choice-1))]}"
-        return
-      elif [[ -n "$choice" ]]; then
-        # if they typed a name, accept if it exists in full list
-        if printf "%s\n" "${rgs[@]}" | grep -Fxq "$choice"; then
-          echo "$choice"
-          return
-        else
-          echo "No exact RG '$choice' found."
-        fi
-      fi
-    else
-      echo "No RGs found starting with '$input'."
+      printf '\n%s\n' "${matches[@]}"
+      printf '%s' "${prompt} ${READLINE_LINE}"
     fi
-  done
+  }
+
+  if bind -x '"\t":_rg_tab_complete' 2>/dev/null; then
+    while true; do
+      read -e -p "${prompt} " rg
+      if printf '%s\n' "${rgs[@]}" | grep -Fxq "$rg"; then
+        bind -r '\t'
+        printf '%s' "$rg"
+        return
+      else
+        echo "Invalid resource group. Press TAB for completion."
+      fi
+    done
+  fi
+
+  # if bind failed (non-interactive shell), use numbered menu
+  select_from_list "$prompt" "${rgs[@]}"
 }
 menu_pick() {
   # menu_pick "Prompt" array_items...

--- a/azDeployGroup/azDeployGroup.sh
+++ b/azDeployGroup/azDeployGroup.sh
@@ -102,18 +102,35 @@ else
 fi
 
 
-# ---------- 4) location (default WestEurope) ----------
-location=""
-prefill_read location "Deployment location: " "WestEurope"
-
-# ---------- 5) resource group name ----------
-read -r -p "Resource group name: " rg_name
+# ---------- 4) resource group name with tab completion ----------
+rg_name=""
+if command -v az >/dev/null 2>&1; then
+  mapfile -t ALL_RGS < <(az group list --query "[].name" -o tsv | sort)
+fi
+if (( ${#ALL_RGS[@]} > 0 )) && [[ -t 0 && -t 1 ]]; then
+  tmpdir="$(mktemp -d)"
+  for rg in "${ALL_RGS[@]}"; do
+    touch "$tmpdir/$rg"
+  done
+  pushd "$tmpdir" >/dev/null
+  while [[ -z "$rg_name" ]]; do
+    read -e -p "Resource group name: " rg_name
+    [[ " ${ALL_RGS[*]} " == *" $rg_name "* ]] || {
+      echo "Invalid resource group. Press Tab for suggestions."
+      rg_name=""
+    }
+  done
+  popd >/dev/null
+  rm -rf "$tmpdir"
+else
+  read -r -p "Resource group name: " rg_name
+fi
 if [[ -z "$rg_name" ]]; then
   err "Resource group name is required."
   exit 1
 fi
 
-# ---------- 6) deployment name ----------
+# ---------- 5) deployment name ----------
 folder_name="$(basename "$PWD")"
 def_deploy="deploy-${folder_name}-$(date +%Y%m%d)"
 deployment_name=""
@@ -124,7 +141,6 @@ echo
 echo "Summary:"
 echo "  Template     : $chosen_bicep"
 echo "  Parameters   : ${chosen_params:-<none>}"
-echo "  Location     : $location"
 echo "  ResourceGroup: $rg_name"
 echo "  Deployment   : $deployment_name"
 echo
@@ -139,7 +155,6 @@ cmd=( az deployment group create
   --resource-group "$rg_name"
   --name "$deployment_name"
   --template-file "$chosen_bicep"
-  --location "$location"
 )
 if [[ -n "$chosen_params" ]]; then
   # Use @file syntax to pass the bicepparam content

--- a/azDeployGroup/azDeployGroup.sh
+++ b/azDeployGroup/azDeployGroup.sh
@@ -42,44 +42,6 @@ prefill_read() {
   tmp="${tmp:-$def}"
   printf -v "$__var" "%s" "$tmp"
 }
-
-spinner_until() {
-  # spinner_until pid "message"
-  local pid="$1" msg="$2"
-  local spin='|/-\' i=0
-  printf "%s " "$msg"
-  while kill -0 "$pid" 2>/dev/null; do
-    printf "\r%s %s" "$msg" "${spin:i++%${#spin}:1}"
-    sleep 0.1
-  done
-  printf "\r%-60s\r" ""  # clear line
-}
-
-pick_rg_by_search() {
-  # pick_rg_by_search array_rgs...
-  local rgs=("$@") term matches rg
-  while true; do
-    read -r -p "Search resource groups (blank to list all): " term
-    if [[ -z "$term" ]]; then
-      matches=("${rgs[@]}")
-    else
-      mapfile -t matches < <(printf "%s\n" "${rgs[@]}" | grep -i -- "$term" || true)
-    fi
-    if (( ${#matches[@]} == 0 )); then
-      echo "No resource groups match '$term'. Try again."
-      continue
-    fi
-    echo "Matching resource groups:"
-    printf '  %s\n' "${matches[@]}"
-    read -r -p "Resource group name: " rg
-    if printf '%s\n' "${rgs[@]}" | grep -Fxq -- "$rg"; then
-      printf '%s' "$rg"
-      return
-    else
-      echo "Resource group '$rg' not found. Try again."
-    fi
-  done
-}
 menu_pick() {
   # menu_pick "Prompt" array_items...
   local prompt="$1"; shift
@@ -144,36 +106,18 @@ fi
 location=""
 prefill_read location "Deployment location: " "WestEurope"
 
-# ---------- 5) fetch RGs in background ----------
-tmp_rg="$(mktemp)"
-cleanup() { rm -f "$tmp_rg"; }
-trap cleanup EXIT
-
-# kick off background query
-( az group list --query "[].name" -o tsv > "$tmp_rg" ) &
-rg_pid=$!
-
-# ---------- do other prompts while RGs load ----------
-echo "Collecting resource groups in background…"
-
-# ---------- 6) ask for RG with assisted picker ----------
-# ensure the RG list is ready; if not, show a spinner
-if kill -0 "$rg_pid" 2>/dev/null; then
-  spinner_until "$rg_pid" "Fetching resource groups"
-fi
-wait "$rg_pid" || { err "Failed to query resource groups. Are you logged in and the subscription selected? (az login / az account set)"; exit 1; }
-
-if [[ ! -s "$tmp_rg" ]]; then
-  err "No resource groups found in the current subscription."
-  exit 1
-fi
-mapfile -t RGS < "$tmp_rg"
-
-rg_name="$(pick_rg_by_search "${RGS[@]}")"
+# ---------- 5) resource group name ----------
+read -r -p "Resource group name: " rg_name
 if [[ -z "$rg_name" ]]; then
-  err "No resource group selected."
+  err "Resource group name is required."
   exit 1
 fi
+
+# ---------- 6) deployment name ----------
+folder_name="$(basename "$PWD")"
+def_deploy="deploy-${folder_name}-$(date +%Y%m%d)"
+deployment_name=""
+prefill_read deployment_name "Deployment name: " "$def_deploy"
 
 # ---------- 7) summary & confirm ----------
 echo
@@ -182,6 +126,7 @@ echo "  Template     : $chosen_bicep"
 echo "  Parameters   : ${chosen_params:-<none>}"
 echo "  Location     : $location"
 echo "  ResourceGroup: $rg_name"
+echo "  Deployment   : $deployment_name"
 echo
 
 if ! ask_yn "Proceed with deployment?" "N"; then
@@ -192,6 +137,7 @@ fi
 # ---------- 8) deploy ----------
 cmd=( az deployment group create
   --resource-group "$rg_name"
+  --name "$deployment_name"
   --template-file "$chosen_bicep"
   --location "$location"
 )

--- a/azDeployGroup/azDeployGroup.sh
+++ b/azDeployGroup/azDeployGroup.sh
@@ -43,14 +43,15 @@ prefill_read() {
   printf -v "$__var" "%s" "$tmp"
 }
 menu_pick() {
-  # menu_pick "Prompt" array_items...
+  # menu_pick var_name "Prompt" array_items...
+  local __var="$1"; shift
   local prompt="$1"; shift
   local items=("$@")
   local PS3="Enter number (1-${#items[@]}): "
   echo "$prompt"
   select opt in "${items[@]}"; do
     if [[ -n "$opt" ]]; then
-      printf "%s" "$opt"
+      printf -v "$__var" "%s" "$opt"
       break
     else
       echo "Invalid choice."
@@ -96,7 +97,7 @@ else
     fi
   else
     if ask_yn "Use a parameters file?" "Y"; then
-      chosen_params="$(menu_pick "Select parameters file:" "${PARAMS[@]}")"
+      menu_pick chosen_params "Select parameters file:" "${PARAMS[@]}"
     fi
   fi
 fi

--- a/azureBastion/agents.md
+++ b/azureBastion/agents.md
@@ -1,0 +1,59 @@
+# azureBastion
+
+## Purpose
+
+`azureBastionSsh.sh` — connects to an Azure VM via Azure Bastion using SSH key authentication. Resolves the VM and Bastion host automatically from the current Azure subscription.
+
+## Usage
+
+```bash
+./azureBastionSsh.sh -u USERNAME -s SSH_KEY -v VM_NAME [-g RESOURCE_GROUP]
+```
+
+| Flag | Long form | Required | Description |
+|------|-----------|----------|-------------|
+| `-u` | `--username` | yes | SSH username on the target VM |
+| `-s` | `--ssh-key` | no* | Path to the SSH private key (`~` expansion supported). Optional if a previous connection exists in history |
+| `-v` | `--vmname` | yes | Name of the target VM |
+| `-g` | `--resource-group` | no | Resource group of the VM (skips subscription-wide search) |
+| | `--dry-run` | no | Print the `az` command without executing it |
+| | `--no-history` | no | Ignore history and resolve VM/Bastion from Azure |
+| `-h` | `--help` | no | Show help and exit |
+
+## Prerequisites
+
+- `az` (Azure CLI) installed and authenticated (`az login`)
+- Azure Bastion host with **Standard or Premium SKU** (Basic is rejected — does not support native SSH tunneling)
+- SSH private key accessible at the given path
+
+## Behavior
+
+### History
+On each successful connection, the script saves the VM/Bastion resolution to `~/.azurebastion` (TSV, 50-entry cap, newest first). On the next run for the same VM name, it offers to reuse the cached result — skipping all Azure API calls. Pass `--no-history` to bypass the cache and force a fresh lookup.
+
+The SSH key path is also stored in history. If `-s` is omitted on a subsequent run, the cached key is used automatically.
+
+### VM resolution
+- If `-g` is provided: looks up the VM directly in that resource group.
+- Otherwise: searches all VMs in the subscription by name.
+  - Single match → used automatically.
+  - Multiple matches → interactive numbered prompt to select one.
+
+### Bastion selection
+Picks the most local Bastion host using a priority cascade:
+1. Same resource group as the VM
+2. Same Azure region as the VM
+3. Any Bastion in the subscription
+
+If multiple hosts qualify at the chosen tier, an interactive prompt is shown.
+
+### Connection
+Delegates to `az network bastion ssh` with `--auth-type ssh-key`.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `azureBastionSsh.sh` | Main script — all logic lives here |
+| `install.sh` | Copies the script to `~/.local/bin/azureBastionSsh` with `755` permissions |
+| `.claude/settings.local.json` | Claude Code local permissions (allows `chmod` and `git` commands) |

--- a/azureBastion/azureBastionSsh.sh
+++ b/azureBastion/azureBastionSsh.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+
+USERNAME=""
+SSH_KEY=""
+VM_NAME=""
+RESOURCE_GROUP=""
+DRY_RUN=0
+SKIP_HISTORY=0
+USE_HISTORY=0
+HISTORY_FILE="${HOME}/.azurebastion"
+
+usage() {
+    cat <<EOF
+Usage: $SCRIPT_NAME -u USERNAME -s SSH_KEY -v VM_NAME [-g RESOURCE_GROUP]
+
+Connect to an Azure VM through Azure Bastion using Azure CLI.
+
+Required options:
+  -u, --username        SSH username for the VM
+  -s, --ssh-key         Path to the SSH private key
+  -v, --vmname          Name of the target VM
+
+Optional options:
+  -g, --resource-group  Resource group of the VM
+      --dry-run         Print the az command without executing it
+      --no-history      Ignore history and resolve VM/Bastion from Azure
+  -h, --help            Show this help and exit
+
+Examples:
+  $SCRIPT_NAME -u dbas -s ~/.ssh/id_ed25519 -v slictprdjhic1
+  $SCRIPT_NAME -u dbas -s ~/.ssh/id_ed25519 -v slictprdjhic1 -g my-resource-group
+EOF
+}
+
+err() {
+    printf "Error: %s\n" "$*" >&2
+}
+
+expand_path() {
+    local path="$1"
+
+    case "$path" in
+        "~")
+            printf "%s\n" "$HOME"
+            ;;
+        "~/"*)
+            printf "%s/%s\n" "$HOME" "${path#~/}"
+            ;;
+        *)
+            printf "%s\n" "$path"
+            ;;
+    esac
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || {
+        err "Required command not found: $1"
+        exit 1
+    }
+}
+
+prompt_choice() {
+    local prompt="$1"
+    shift
+    local options=("$@")
+    local i choice
+
+    printf "%s\n" "$prompt" >&2
+    for i in "${!options[@]}"; do
+        printf "  %d) %s\n" "$((i + 1))" "${options[$i]}" >&2
+    done
+
+    while true; do
+        read -r -p "Enter number (1-${#options[@]}): " choice
+        if [[ "$choice" =~ ^[0-9]+$ ]] && (( choice >= 1 && choice <= ${#options[@]} )); then
+            printf "%s\n" "${options[$((choice - 1))]}"
+            return 0
+        fi
+        printf "Invalid choice.\n" >&2
+    done
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            -u|--username)
+                [[ $# -ge 2 ]] || {
+                    err "Missing value for $1"
+                    usage
+                    exit 1
+                }
+                USERNAME="$2"
+                shift 2
+                ;;
+            -s|--ssh-key)
+                [[ $# -ge 2 ]] || {
+                    err "Missing value for $1"
+                    usage
+                    exit 1
+                }
+                SSH_KEY="$2"
+                shift 2
+                ;;
+            -v|--vmname)
+                [[ $# -ge 2 ]] || {
+                    err "Missing value for $1"
+                    usage
+                    exit 1
+                }
+                VM_NAME="$2"
+                shift 2
+                ;;
+            -g|--resource-group)
+                [[ $# -ge 2 ]] || {
+                    err "Missing value for $1"
+                    usage
+                    exit 1
+                }
+                RESOURCE_GROUP="$2"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=1
+                shift
+                ;;
+            --no-history)
+                SKIP_HISTORY=1
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                err "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    if [[ -z "$USERNAME" || -z "$VM_NAME" ]]; then
+        err "Missing required options."
+        usage
+        exit 1
+    fi
+}
+
+try_history() {
+    (( SKIP_HISTORY )) && return 1
+    [[ -f "$HISTORY_FILE" ]] || return 1
+
+    local h_vm_name h_vm_rg h_vm_loc h_vm_id h_bast_name h_bast_rg h_bast_loc h_ssh_key h_ts found=0
+
+    while IFS=$'\t' read -r h_vm_name h_vm_rg h_vm_loc h_vm_id h_bast_name h_bast_rg h_bast_loc h_ssh_key h_ts; do
+        [[ "$h_vm_name" == "$VM_NAME" ]] || continue
+        if [[ -n "$RESOURCE_GROUP" && "$h_vm_rg" != "$RESOURCE_GROUP" ]]; then
+            continue
+        fi
+        found=1
+        break
+    done < "$HISTORY_FILE"
+
+    if [[ "$found" -eq 0 ]]; then return 1; fi
+
+    printf "Found previous connection for '%s':\n" "$VM_NAME"
+    printf "  VM:        %s (resource group: %s, %s)\n" "$VM_NAME" "$h_vm_rg" "$h_vm_loc"
+    printf "  Bastion:   %s (resource group: %s, %s)\n" "$h_bast_name" "$h_bast_rg" "$h_bast_loc"
+    printf "  SSH key:   %s\n" "$h_ssh_key"
+    printf "  Last used: %s\n" "$h_ts"
+
+    local answer
+    read -r -p "Use previous connection? [Y/n]: " answer
+    case "${answer,,}" in
+        ""|y|yes)
+            VM_ID="$h_vm_id"
+            VM_RESOURCE_GROUP="$h_vm_rg"
+            VM_LOCATION="$h_vm_loc"
+            BASTION_NAME="$h_bast_name"
+            BASTION_RESOURCE_GROUP="$h_bast_rg"
+            BASTION_LOCATION="$h_bast_loc"
+            [[ -z "$SSH_KEY" ]] && SSH_KEY="$h_ssh_key"
+            USE_HISTORY=1
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+save_to_history() {
+    local timestamp new_entry tmp_file vm_name vm_rg count
+    timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    new_entry="$(printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s" \
+        "$VM_NAME" "$VM_RESOURCE_GROUP" "$VM_LOCATION" "$VM_ID" \
+        "$BASTION_NAME" "$BASTION_RESOURCE_GROUP" "$BASTION_LOCATION" \
+        "$SSH_KEY" "$timestamp")"
+
+    tmp_file="$(mktemp)"
+    printf "%s\n" "$new_entry" > "$tmp_file"
+
+    if [[ -f "$HISTORY_FILE" ]]; then
+        count=0
+        while IFS=$'\t' read -r vm_name vm_rg rest; do
+            if [[ "$vm_name" == "$VM_NAME" && "$vm_rg" == "$VM_RESOURCE_GROUP" ]]; then
+                continue
+            fi
+            if [[ "$count" -ge 49 ]]; then break; fi
+            printf "%s\t%s\t%s\n" "$vm_name" "$vm_rg" "$rest" >> "$tmp_file"
+            count=$(( count + 1 ))
+        done < "$HISTORY_FILE"
+    fi
+
+    mv "$tmp_file" "$HISTORY_FILE"
+}
+
+check_prereqs() {
+    require_command az
+
+    if ! az account show >/dev/null 2>&1; then
+        err "Azure CLI is not authenticated. Run 'az login' first."
+        exit 1
+    fi
+
+    if ! az extension show --name ssh --query name --output tsv >/dev/null 2>&1; then
+        err "Azure CLI extension 'ssh' is not installed. Run: az extension add --name ssh"
+        exit 1
+    fi
+
+    SSH_KEY="$(expand_path "$SSH_KEY")"
+    if [[ ! -f "$SSH_KEY" ]]; then
+        err "SSH key file not found: $SSH_KEY"
+        exit 1
+    fi
+
+    local perm
+    perm="$(stat -c "%a" "$SSH_KEY")"
+    if [[ "${perm: -2}" != "00" ]]; then
+        err "SSH key has insecure permissions ($perm). Run: chmod 600 \"$SSH_KEY\""
+        exit 1
+    fi
+}
+
+resolve_vm() {
+    local matches choice
+
+    if [[ -n "$RESOURCE_GROUP" ]]; then
+        if ! VM_ID="$(az vm show \
+            --resource-group "$RESOURCE_GROUP" \
+            --name "$VM_NAME" \
+            --query id \
+            --output tsv 2>/dev/null)"; then
+            err "VM '$VM_NAME' not found in resource group '$RESOURCE_GROUP'."
+            exit 1
+        fi
+
+        VM_LOCATION="$(az vm show \
+            --resource-group "$RESOURCE_GROUP" \
+            --name "$VM_NAME" \
+            --query location \
+            --output tsv)"
+        VM_RESOURCE_GROUP="$RESOURCE_GROUP"
+        return 0
+    fi
+
+    mapfile -t VM_MATCHES < <(
+        az vm list \
+            --query "[?name=='$VM_NAME'].[id, resourceGroup, location]" \
+            --output tsv
+    )
+
+    if (( ${#VM_MATCHES[@]} == 0 )); then
+        err "No VM named '$VM_NAME' found in the current subscription."
+        exit 1
+    fi
+
+    if (( ${#VM_MATCHES[@]} == 1 )); then
+        IFS=$'\t' read -r VM_ID VM_RESOURCE_GROUP VM_LOCATION <<< "${VM_MATCHES[0]}"
+        return 0
+    fi
+
+    mapfile -t matches < <(
+        printf "%s\n" "${VM_MATCHES[@]}" | while IFS=$'\t' read -r id rg location; do
+            printf "%s (resource group: %s, location: %s)\n" "$VM_NAME" "$rg" "$location"
+        done
+    )
+
+    choice="$(prompt_choice "Multiple VMs named '$VM_NAME' were found. Select one:" "${matches[@]}")"
+
+    local index=0
+    for index in "${!matches[@]}"; do
+        if [[ "${matches[$index]}" == "$choice" ]]; then
+            IFS=$'\t' read -r VM_ID VM_RESOURCE_GROUP VM_LOCATION <<< "${VM_MATCHES[$index]}"
+            return 0
+        fi
+    done
+
+    err "Failed to resolve VM selection."
+    exit 1
+}
+
+check_vm_state() {
+    local state
+    state="$(az vm get-instance-view \
+        --resource-group "$VM_RESOURCE_GROUP" \
+        --name "$VM_NAME" \
+        --query "instanceView.statuses[?starts_with(code, 'PowerState/')].displayStatus" \
+        --output tsv | tr -d '\r')"
+
+    if [[ "$state" != "VM running" ]]; then
+        err "VM '$VM_NAME' is not running (current state: ${state:-unknown})."
+        exit 1
+    fi
+}
+
+choose_bastion() {
+    local bastion_lines=()
+    local preferred_lines=()
+    local fallback_lines=()
+    local any_lines=()
+    local choice
+
+    mapfile -t bastion_lines < <(
+        az network bastion list \
+            --query "[].[name, resourceGroup, location, id]" \
+            --output tsv
+    )
+
+    if (( ${#bastion_lines[@]} == 0 )); then
+        err "No Azure Bastion hosts found in the current subscription."
+        exit 1
+    fi
+
+    local line name rg location id
+    for line in "${bastion_lines[@]}"; do
+        IFS=$'\t' read -r name rg location id <<< "$line"
+        if [[ "$rg" == "$VM_RESOURCE_GROUP" ]]; then
+            preferred_lines+=("$line")
+        elif [[ "$location" == "$VM_LOCATION" ]]; then
+            fallback_lines+=("$line")
+        else
+            any_lines+=("$line")
+        fi
+    done
+
+    local selected_pool=()
+    if (( ${#preferred_lines[@]} > 0 )); then
+        selected_pool=("${preferred_lines[@]}")
+    elif (( ${#fallback_lines[@]} > 0 )); then
+        selected_pool=("${fallback_lines[@]}")
+    else
+        selected_pool=("${any_lines[@]}")
+    fi
+
+    if (( ${#selected_pool[@]} == 1 )); then
+        IFS=$'\t' read -r BASTION_NAME BASTION_RESOURCE_GROUP BASTION_LOCATION BASTION_ID <<< "${selected_pool[0]}"
+        return 0
+    fi
+
+    mapfile -t BASTION_DISPLAY < <(
+        printf "%s\n" "${selected_pool[@]}" | while IFS=$'\t' read -r name rg location id; do
+            printf "%s (resource group: %s, location: %s)\n" "$name" "$rg" "$location"
+        done
+    )
+
+    choice="$(prompt_choice "Multiple Bastion hosts are suitable. Select one:" "${BASTION_DISPLAY[@]}")"
+
+    local index=0
+    for index in "${!BASTION_DISPLAY[@]}"; do
+        if [[ "${BASTION_DISPLAY[$index]}" == "$choice" ]]; then
+            IFS=$'\t' read -r BASTION_NAME BASTION_RESOURCE_GROUP BASTION_LOCATION BASTION_ID <<< "${selected_pool[$index]}"
+            return 0
+        fi
+    done
+
+    err "Failed to resolve Bastion selection."
+    exit 1
+}
+
+check_bastion_sku() {
+    local sku
+    sku="$(az network bastion show \
+        --name "$BASTION_NAME" \
+        --resource-group "$BASTION_RESOURCE_GROUP" \
+        --query "sku.name" \
+        --output tsv)"
+
+    if [[ "$sku" == "Basic" ]]; then
+        err "Bastion '$BASTION_NAME' uses the Basic SKU, which does not support native SSH. Upgrade to Standard or Premium."
+        exit 1
+    fi
+}
+
+run_bastion_ssh() {
+    printf "Using VM '%s' in resource group '%s' (%s).\n" "$VM_NAME" "$VM_RESOURCE_GROUP" "$VM_LOCATION"
+    printf "Using Bastion '%s' in resource group '%s' (%s).\n" "$BASTION_NAME" "$BASTION_RESOURCE_GROUP" "$BASTION_LOCATION"
+
+    local cmd=(
+        az network bastion ssh
+        --name "$BASTION_NAME"
+        --resource-group "$BASTION_RESOURCE_GROUP"
+        --target-resource-id "$VM_ID"
+        --auth-type ssh-key
+        --username "$USERNAME"
+        --ssh-key "$SSH_KEY"
+    )
+
+    if (( DRY_RUN )); then
+        printf "Dry run — would execute:\n  %s\n" "${cmd[*]}"
+        return 0
+    fi
+
+    "${cmd[@]}"
+}
+
+main() {
+    parse_args "$@"
+    try_history || true
+    if [[ -z "$SSH_KEY" ]]; then
+        err "Missing required option: -s / --ssh-key"
+        usage
+        exit 1
+    fi
+    check_prereqs
+    if [[ "$USE_HISTORY" -eq 0 ]]; then
+        resolve_vm
+        choose_bastion
+        check_bastion_sku
+    fi
+    check_vm_state
+    run_bastion_ssh
+    if [[ "$DRY_RUN" -eq 0 ]]; then
+        save_to_history
+    fi
+}
+
+main "$@"

--- a/azureBastion/install.sh
+++ b/azureBastion/install.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+INSTALL_DIR="${HOME}/.local/bin"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="${INSTALL_DIR}/azureBastionSsh"
+
+install -D -m 755 "${SCRIPT_DIR}/azureBastionSsh.sh" "${TARGET}"
+printf "Installed: %s\n" "${TARGET}"
+
+if [[ ":${PATH}:" != *":${INSTALL_DIR}:"* ]]; then
+    printf "Note: '%s' is not in your PATH.\n" "${INSTALL_DIR}"
+    printf "Add this to your shell config:  export PATH=\"%s:\$PATH\"\n" "${INSTALL_DIR}"
+fi


### PR DESCRIPTION
## Summary
- enable tab-based completion when choosing a resource group in `azDeployGroup.sh`
- fall back to numbered menu if interactive completion isn't available

## Testing
- `bash -n azDeployGroup.sh`
- `shellcheck azDeployGroup.sh` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.2.179 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68ad9e39ce38832693c7d80315179e40