### PR TITLE
feat(pimMe): add pim-activate.sh, interactive azure pim role activation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Artefacts WSL sur fichiers telecharges depuis Windows
+*:Zone.Identifier

--- a/pimMe/README.md
+++ b/pimMe/README.md
@@ -1,0 +1,125 @@
+# pim-activate.sh
+
+Activation interactive de rôles PIM **de ressources Azure**, en alternative au
+portail : lister ses rôles éligibles, en activer un après justification, suivre
+le provisionnement, enchaîner — sans quitter le script.
+
+Le chemin Entra ID (rôles d'annuaire via Microsoft Graph) a été retiré : le
+script ne parle qu'à l'API ARM.
+
+## Prérequis
+
+- `bash` 4+, `jq`, `az` (Azure CLI) avec une session ouverte (`az login`) ;
+- `uuidgen` facultatif (repli sur `/proc/sys/kernel/random/uuid`).
+
+Le script ne déclenche jamais de `az login` : il constate et informe.
+
+## Utilisation
+
+```
+./pim-activate.sh [-s|--scope azure] [-h|--help]
+```
+
+`--help` détaille options, navigation, règle de justification et limitations.
+
+Dans la liste : flèches ou numéro pour choisir, `Entrée` pour activer, `r` pour
+recharger, `q` pour quitter, `Ctrl+C` pour annuler la saisie ou l'attente en
+cours sans quitter.
+
+## Exemple d'exécution
+
+Session réelle (deux activations enchaînées, sortie par `q`) :
+
+```
+$ ./pim-activate.sh
+Connecté en tant que ADM_XXX@example.be (tenant bb2cf736-…).
+Chargement des rôles eligible (scope azure)…
+Rôles azure eligible (19) — Entrée active, r recharge, q quitte :
+   1) Contributor  —  managementgroup MG-Brucity
+   …
+> 16) Reader  —  managementgroup Tenant Root Group
+   17) User Access Administrator  —  subscription LZ-CPAS
+Flèches haut/bas + Entrée, numéro + Entrée, q pour annuler : (r)
+
+Rôle sélectionné :
+  libellé              : Reader  —  managementgroup Tenant Root Group
+  roleDefinitionId     : /providers/…/roleDefinitions/acdd72a7-…
+  scope                : /providers/Microsoft.Management/managementGroups/bb2cf736-…
+  schedule eligible    : /providers/…/roleEligibilitySchedules/66701712-…
+
+Justification (Entrée valide, ligne vide annule) : Validation goal 4 - premier role du cycle
+
+Soumission de la demande (8h)…
+Attente du provisionnement .
+Rôle activé (Provisioned) pour 8h.
+Chargement des rôles eligible (scope azure)…            ← retour automatique
+Rôles azure eligible (19) — Entrée active, r recharge, q quitte :
+…
+17
+Rôle sélectionné :
+  libellé              : User Access Administrator  —  subscription LZ-CPAS
+  …
+Rôle sensible (User Access Administrator) :
+justification obligatoire, aucun texte n'est pré-rempli.
+Justification obligatoire (Ctrl+C annule) :
+Erreur : Justification obligatoire pour ce rôle : saisissez un motif (Ctrl+C pour annuler).
+Justification obligatoire (Ctrl+C annule) : Revue des acces LZ-CPAS - demande utilisateur
+
+Soumission de la demande (8h)…
+Attente du provisionnement .
+Rôle activé (Provisioned) pour 8h.
+Chargement des rôles eligible (scope azure)…
+Rôles azure eligible (19) — Entrée active, r recharge, q quitte :
+q
+Sortie.
+$ echo $?
+0
+```
+
+### Justification
+
+Une justification pré-remplie et modifiable est proposée. Sur **Owner** et
+**User Access Administrator**, elle devient obligatoire : rien n'est pré-rempli
+et une ligne vide est refusée — un placeholder validé d'un coup d'`Entrée` ne
+documente rien, et c'est sur ces deux rôles que la trace doit être réelle.
+
+### Erreurs et interruptions
+
+Un appel `az` qui échoue (réseau coupé, droits manquants, politique PIM, rôle
+déjà actif) est traduit en message actionnable, suivi du détail brut, puis
+ramène à la liste :
+
+```
+Soumission de la demande (8h)…
+Erreur : Échec de la soumission de l'activation Azure.
+Erreur : Appel Azure impossible : le réseau ou le service ne répond pas.
+Erreur : Vérifiez la connectivité (proxy, VPN, DNS) puis rechargez la liste.
+ERROR: HTTPSConnectionPool(host='management.azure.com', port=443): Max retries exceeded…
+Chargement des rôles eligible (scope azure)…
+```
+
+Si la liste elle-même ne peut plus être chargée, le script demande
+`Recharger la liste ? [O/n]` plutôt que de boucler indéfiniment.
+
+`Ctrl+C` pendant la saisie ou le polling revient à la liste, terminal rendu
+intact (échos et curseur restaurés) ; une demande déjà soumise continue d'être
+traitée côté Azure et reste consultable dans le portail.
+
+## Tests
+
+```
+bash tests/test_menu.sh         # menu : navigation, saisie, annulation, hotkeys
+bash tests/test_activation.sh   # corps de requête, justification, diagnostics
+bash tests/test_interrupt.sh    # Ctrl+C réel (signal au groupe) + état du tty
+```
+
+`test_interrupt.sh` émet de vrais appels `az` (session ouverte requise) et
+utilise `python3` pour le pty ; il n'active aucun rôle.
+
+## Limitations connues
+
+- pas de désactivation d'un rôle actif (passer par le portail) ;
+- workflow d'approbation non géré : une demande `PendingApproval` est affichée
+  puis abandonnée après 60 s de polling, sans être annulée ;
+- mono-tenant : celui de la session `az` courante ;
+- rôles d'annuaire Entra ID non gérés.

--- a/pimMe/README.md
+++ b/pimMe/README.md
@@ -17,7 +17,7 @@ Le script ne déclenche jamais de `az login` : il constate et informe.
 ## Utilisation
 
 ```
-./pim-activate.sh [-s|--scope azure] [-h|--help]
+./pim-activate.sh [-h|--help]
 ```
 
 `--help` détaille options, navigation, règle de justification et limitations.
@@ -33,8 +33,8 @@ Session réelle (deux activations enchaînées, sortie par `q`) :
 ```
 $ ./pim-activate.sh
 Connecté en tant que ADM_XXX@example.be (tenant bb2cf736-…).
-Chargement des rôles eligible (scope azure)…
-Rôles azure eligible (19) — Entrée active, r recharge, q quitte :
+Chargement des rôles eligible…
+Rôles eligible (19) — Entrée active, r recharge, q quitte :
    1) Contributor  —  managementgroup MG-Brucity
    …
 > 16) Reader  —  managementgroup Tenant Root Group
@@ -52,8 +52,8 @@ Justification (Entrée valide, ligne vide annule) : Validation goal 4 - premier 
 Soumission de la demande (8h)…
 Attente du provisionnement .
 Rôle activé (Provisioned) pour 8h.
-Chargement des rôles eligible (scope azure)…            ← retour automatique
-Rôles azure eligible (19) — Entrée active, r recharge, q quitte :
+Chargement des rôles eligible…            ← retour automatique
+Rôles eligible (19) — Entrée active, r recharge, q quitte :
 …
 17
 Rôle sélectionné :
@@ -68,8 +68,8 @@ Justification obligatoire (Ctrl+C annule) : Revue des acces LZ-CPAS - demande ut
 Soumission de la demande (8h)…
 Attente du provisionnement .
 Rôle activé (Provisioned) pour 8h.
-Chargement des rôles eligible (scope azure)…
-Rôles azure eligible (19) — Entrée active, r recharge, q quitte :
+Chargement des rôles eligible…
+Rôles eligible (19) — Entrée active, r recharge, q quitte :
 q
 Sortie.
 $ echo $?
@@ -95,7 +95,7 @@ Erreur : Échec de la soumission de l'activation Azure.
 Erreur : Appel Azure impossible : le réseau ou le service ne répond pas.
 Erreur : Vérifiez la connectivité (proxy, VPN, DNS) puis rechargez la liste.
 ERROR: HTTPSConnectionPool(host='management.azure.com', port=443): Max retries exceeded…
-Chargement des rôles eligible (scope azure)…
+Chargement des rôles eligible…
 ```
 
 Si la liste elle-même ne peut plus être chargée, le script demande

--- a/pimMe/goal-1-foundations.md
+++ b/pimMe/goal-1-foundations.md
@@ -1,0 +1,48 @@
+---
+statut: à valider
+maj: 2026-08-27
+tags: [goal, script, pim, claude-code]
+---
+# Goal 1 — Squelette, auth check, parsing d'arguments, composant menu
+
+## Contexte
+
+Premier goal d'une série de 4 pour construire `pim-activate.sh`, un script bash interactif d'activation de rôles PIM Azure/Entra. Voir `plan.md` (même dossier) pour la vue d'ensemble et les décisions de design déjà actées. Ce goal ne doit PAS implémenter la logique métier PIM (listing, activation) — uniquement les fondations.
+
+## Objectif
+
+Livrer un script `pim-activate.sh` exécutable qui :
+
+1. Vérifie la présence de `az` et `jq` dans le PATH ; message d'erreur clair et sortie non-zéro si l'un des deux manque.
+2. Vérifie l'authentification via `az account show` ; si KO, message clair invitant à lancer `az login`, puis sortie non-zéro (pas de login automatique déclenché par le script).
+3. Parse les arguments :
+   - `-s`, `--scope` : valeurs autorisées `azure` | `entra`, défaut `azure` ; valeur invalide → message d'erreur et sortie non-zéro.
+   - `-h`, `--help` : affiche l'usage et sort en 0.
+4. Expose une fonction de menu interactif réutilisable (nom suggéré : `select_from_menu`) :
+   - Entrée : un tableau bash de libellés (les options à afficher).
+   - Affichage : liste numérotée, avec la ligne courante surlignée.
+   - Navigation : flèches haut/bas pour déplacer la sélection, Entrée pour valider ; OU saisie directe d'un numéro suivi d'Entrée.
+   - `q` annule le menu sans sélection (retour explicite exploitable par l'appelant, ex. code de sortie ou variable dédiée).
+   - Retourne l'index (ou le libellé) sélectionné de façon exploitable par le reste du script.
+   - Implémentation en bash pur (`read -rsn1`, séquences ANSI `\e[A` / `\e[B`), sans dépendance externe.
+
+## Contraintes techniques
+
+- `set -euo pipefail` en tête de script.
+- Bash requis (tableaux, `read -rsn1`) — pas de compatibilité sh POSIX strict à viser.
+- Fichier unique `pim-activate.sh`.
+- En-tête de fichier en commentaire : usage, prérequis (`az` connecté, `jq`), description courte.
+
+## Critères d'acceptation
+
+- `./pim-activate.sh --help` affiche l'usage et sort en 0, sans appeler `az`.
+- `./pim-activate.sh --scope invalide` sort en erreur avec message clair, sans appeler `az`.
+- Sans authentification `az` valide, le script affiche une erreur claire et sort en non-zéro sans stack trace brute.
+- La fonction de menu, testable isolément (bloc de test ou petit script séparé), permet de sélectionner un élément parmi 3-4 entrées factices, à la fois par flèches et par numéro, et gère `q` proprement.
+- Aucune logique de listing ou d'activation PIM dans ce goal.
+
+## Hors scope de ce goal
+
+- Tout appel `az rest` vers ARM ou Microsoft Graph.
+- Le flux de justification/activation.
+- La boucle principale complète (assemblée dans `goal-4-main-loop.md`).

--- a/pimMe/goal-2-list-roles.md
+++ b/pimMe/goal-2-list-roles.md
@@ -1,0 +1,54 @@
+---
+statut: à valider
+maj: 2026-08-27
+tags: [goal, script, pim, claude-code]
+---
+# Goal 2 — Listing des rôles PIM eligible (Azure + Entra) et switch de scope
+
+## Contexte
+
+Deuxième goal de la série `pim-activate.sh` (voir `plan.md`, même dossier). Part du squelette livré par `goal-1-foundations.md` (auth check, parsing d'arguments, composant `select_from_menu`) et y branche la récupération réelle des rôles eligible. Si `goal-1` n'a pas encore été exécuté dans ce projet, l'implémenter d'abord.
+
+## Objectif
+
+### 1. Azure resource roles (ARM)
+
+- Récupérer l'objectId de l'utilisateur courant : `az ad signed-in-user show --query id -o tsv`.
+- Identifier un scope racine du tenant (ex. management group racine via `az account management-group list` ou équivalent).
+- Appel `az rest` GET sur :
+  `https://management.azure.com/{scope}/providers/Microsoft.Authorization/roleEligibilityScheduleInstances?api-version=2020-10-01&$filter=principalId eq '{principalId}'`
+- Parser la réponse avec `jq` pour extraire, par rôle eligible : nom du rôle (peut nécessiter un lookup complémentaire sur `roleDefinitionId` si le nom n'est pas inclus), scope, et l'identifiant nécessaire à l'activation (`roleEligibilityScheduleId` ou équivalent présent dans la réponse).
+- **Hypothèse de design (cf. plan.md)** : ce filtre sur un scope racine est censé cascader sur toutes les souscriptions. Si la réponse est vide ou incomplète en test réel, fallback = boucler sur `az account list --query "[].id" -o tsv` et interroger le même endpoint par souscription avec `$filter=asTarget()`. Documenter en commentaire de code le chemin effectivement retenu et pourquoi.
+
+### 2. Entra ID directory roles (Graph)
+
+- Appel `az rest` GET sur :
+  `https://graph.microsoft.com/v1.0/roleManagement/directory/roleEligibilityScheduleInstances/filterByCurrentUser(on='principal')`
+- Parser la réponse pour extraire : nom du rôle (`roleDefinition/displayName` si expand disponible, sinon lookup séparé sur `roleDefinitionId`), et l'identifiant nécessaire à l'activation (`id` de l'instance).
+
+### 3. Affichage
+
+- Construire la liste de libellés (nom du rôle + scope pour Azure) et l'afficher via `select_from_menu` (goal-1).
+- Liste vide pour le scope courant → message clair (« Aucun rôle eligible sur ce scope »), pas de menu vide silencieux.
+
+### 4. Switch de scope
+
+- Depuis l'écran de liste, une touche dédiée bascule le scope courant (`a` = azure, `e` = entra) et rafraîchit la liste correspondante. Documenter le choix d'implémentation (extension de `select_from_menu` vs couche au-dessus).
+
+## Contraintes techniques
+
+- `jq` pour tout parsing JSON — pas de regex sur du JSON brut.
+- Factoriser l'appel `az rest` commun (méthode, url, filtre) entre Azure et Entra si le pattern s'y prête.
+- Chaque rôle listé doit porter avec lui toutes les infos nécessaires (roleDefinitionId, scope ou directoryScopeId, identifiant de la schedule eligible) pour que `goal-3-activation-flow.md` puisse construire la requête d'activation sans re-quêter l'API.
+
+## Critères d'acceptation
+
+- `./pim-activate.sh` (scope par défaut `azure`) affiche la liste réelle des rôles Azure eligible de l'utilisateur connecté (test manuel sur un tenant réel).
+- `./pim-activate.sh --scope entra` affiche la liste réelle des rôles Entra eligible.
+- Bascule de scope par touche fonctionnelle sans relancer le script.
+- Liste vide gérée proprement.
+
+## Hors scope de ce goal
+
+- Le prompt de justification et la soumission d'activation (`goal-3-activation-flow.md`).
+- La boucle de retour au menu après activation (`goal-4-main-loop.md`).

--- a/pimMe/goal-3-activation-flow.md
+++ b/pimMe/goal-3-activation-flow.md
@@ -1,0 +1,49 @@
+---
+statut: à valider
+maj: 2026-08-27
+tags: [goal, script, pim, claude-code]
+---
+# Goal 3 — Justification, soumission de l'activation, polling du statut
+
+## Contexte
+
+Troisième goal de la série `pim-activate.sh` (voir `plan.md`, même dossier). Part du principe qu'un rôle a été sélectionné via le flux livré par `goal-2-list-roles.md`, avec toutes les infos nécessaires (roleDefinitionId, scope/directoryScopeId, identifiant de la schedule eligible, scope courant azure|entra). Si `goal-1`/`goal-2` n'ont pas encore été exécutés dans ce projet, s'appuyer sur leur code existant plutôt que de le redévelopper.
+
+## Objectif
+
+### 1. Prompt de justification
+
+- Afficher un champ de saisie pré-rempli d'un placeholder « business » modifiable (ex. `Intervention support — troubleshooting`), édité en place par l'utilisateur avant validation.
+- Ne jamais soumettre le placeholder sans confirmation explicite : Entrée valide le texte affiché à l'écran, y compris s'il n'a pas été modifié par l'utilisateur.
+
+### 2. Soumission — Azure (ARM)
+
+- `PUT https://management.azure.com/{scope}/providers/Microsoft.Authorization/roleAssignmentScheduleRequests/{guid}?api-version=2020-10-01` (GUID généré via `uuidgen` ou équivalent disponible en bash).
+- Body attendu : `principalId`, `roleDefinitionId`, `requestType: SelfActivate`, `justification`, `scheduleInfo` (`startDateTime` = maintenant, `expiration` = `{type: AfterDuration, duration: PT{N}H}` avec N = `DEFAULT_DURATION_HOURS` défini dans `plan.md`), et `linkedRoleEligibilityScheduleId` si l'API le retourne en erreur comme requis (à vérifier en test, l'ajouter si nécessaire).
+
+### 3. Soumission — Entra (Graph)
+
+- `POST https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignmentScheduleRequests`.
+- Body attendu : `action: selfActivate`, `principalId`, `roleDefinitionId`, `directoryScopeId`, `justification`, `scheduleInfo` (même logique de durée que pour Azure).
+- Si l'appel échoue avec une erreur liée au MFA/claims (HTTP 403, message mentionnant MFA ou claims challenge), afficher un message explicite : le rôle nécessite une session MFA fraîche, suggérer de relancer `az login` puis de réessayer. Ne pas faire planter le script.
+
+### 4. Polling du statut
+
+- Après soumission, poll GET sur la ressource créée (`roleAssignmentScheduleRequests/{guid}` côté ARM, `roleAssignmentScheduleRequests/{id}` côté Graph) toutes les 3-5 secondes environ.
+- États à distinguer à l'affichage :
+  - `Provisioned` → succès, sortie de boucle.
+  - `Failed` / `Cancelled` → échec, afficher le message d'erreur renvoyé par l'API si présent.
+  - `PendingApproval` → afficher l'état, sortir du polling après un timeout (60s, cf. plan.md) sans gérer le workflow d'approbation.
+- Indicateur d'attente simple pendant le polling (spinner ou points qui s'accumulent).
+
+## Critères d'acceptation
+
+- Sur un rôle Azure eligible réel, activation de bout en bout jusqu'à `Provisioned` visible dans le portail PIM.
+- Sur un rôle Entra eligible réel, soit activation de bout en bout, soit message d'erreur MFA explicite si la session ne le permet pas — les deux issues sont acceptables pour ce goal, le comportement doit juste être clair et ne pas planter.
+- Justification jamais soumise sans passage explicite par le prompt, même avec le placeholder par défaut inchangé.
+- Timeout de polling respecté sur un rôle configuré avec approbation (si disponible pour test) — pas de boucle infinie.
+
+## Hors scope de ce goal
+
+- La boucle de retour au menu de listing après l'activation (`goal-4-main-loop.md`).
+- Le listing lui-même (déjà couvert par `goal-2-list-roles.md`, réutilisé tel quel en entrée).

--- a/pimMe/goal-4-main-loop.md
+++ b/pimMe/goal-4-main-loop.md
@@ -1,0 +1,38 @@
+---
+statut: à valider
+maj: 2026-08-27
+tags: [goal, script, pim, claude-code]
+---
+# Goal 4 — Intégration finale : boucle principale, gestion d'erreurs globale, doc
+
+## Contexte
+
+Dernier goal de la série `pim-activate.sh` (voir `plan.md`, même dossier). Assemble `goal-1-foundations.md` (squelette/menu), `goal-2-list-roles.md` (listing) et `goal-3-activation-flow.md` (activation) en un flux complet et robuste. S'appuyer sur le code déjà produit par ces trois goals plutôt que de le redévelopper.
+
+## Objectif
+
+### 1. Boucle principale
+
+- Après une activation (succès, échec, ou annulation via `q` depuis le menu de sélection de rôle), retour automatique à l'écran de liste des rôles eligible du scope courant, rafraîchie.
+- Depuis l'écran de liste : sélectionner un rôle relance le flux de justification/activation (`goal-3`) ; switcher de scope (`a`/`e`) rafraîchit la liste correspondante ; `q` quitte proprement le script (code de sortie 0).
+
+### 2. Gestion d'erreurs globale
+
+- Toute erreur `az rest` non gérée spécifiquement par `goal-2`/`goal-3` (timeout réseau, erreur HTTP inattendue) doit être interceptée, affichée de façon lisible (pas de stack trace `set -e` brute), et ramener l'utilisateur à l'écran de liste plutôt que de crasher le script entier.
+- `Ctrl+C` en cours de polling ou de saisie doit être intercepté proprement (trap) et ramener au menu plutôt que de laisser un état de terminal incohérent (ex. curseur invisible après un `read -rsn1` interrompu).
+
+### 3. Documentation finale
+
+- En-tête de script complet : usage (`-h`/`--help` détaillé avec exemples), prérequis, description courte du fonctionnement, limitations connues (pas de désactivation, pas de gestion d'approbation, mono-tenant — cf. `plan.md`, section « hors scope »).
+- Un exemple d'exécution en commentaire ou dans un `README.md` séparé si plus lisible ainsi — choix libre, à documenter dans la PR/commit.
+
+## Critères d'acceptation
+
+- Session complète manuelle : lancer le script, activer un rôle, revenir à la liste, switcher de scope, activer un autre rôle, quitter avec `q` — sans redémarrer le script entre chaque étape.
+- Une erreur réseau simulée (ex. couper la connexion pendant un appel `az rest`) ne fait pas planter le script : message clair, retour au menu.
+- `Ctrl+C` pendant le polling ramène proprement au menu de liste, sans sortie brutale ni terminal cassé.
+- `--help` à jour et complet, cohérent avec le comportement réel du script.
+
+## Hors scope de ce goal
+
+- Toute nouvelle fonctionnalité non prévue dans les goals 1 à 3 (désactivation de rôle, gestion du workflow d'approbation, multi-tenant — cf. `plan.md`).

--- a/pimMe/install.sh
+++ b/pimMe/install.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+#
+# install.sh — Rend pim-activate.sh appelable par son nom depuis n'importe où.
+#
+# Pose un lien symbolique « pim-activate » dans un répertoire bin utilisateur
+# déjà présent dans $PATH. Un lien, pas une copie : le script installé suit les
+# mises à jour du dépôt sans réinstallation.
+#
+# Usage :
+#   ./install.sh [--bin-dir RÉPERTOIRE] [--uninstall] [-h|--help]
+#
+# Fonctionnement :
+#   1. détection des répertoires bin utilisateur présents dans $PATH
+#      (~/.local/bin et ~/bin au minimum) ;
+#   2. si plusieurs conviennent, choix au clavier via le menu de
+#      pim-activate.sh ; si un seul, il est retenu sans question ;
+#   3. si aucun n'est dans $PATH, proposition de créer ~/.local/bin, puis
+#      affichage de la ligne d'export à ajouter au shell rc ;
+#   4. création du lien, refus d'écraser un fichier qui n'est pas déjà notre
+#      lien ;
+#   5. vérification finale par `command -v` dans un shell neuf.
+#
+# Ce que l'installeur n'écrit jamais :
+#   - aucun fichier hors du répertoire bin retenu ;
+#   - ni ~/.bashrc, ni ~/.profile, ni ~/.zshrc — la ligne d'export est
+#     affichée, à vous de l'ajouter ;
+#   - aucun sudo, aucune installation système.
+#
+# Codes de sortie :
+#   0   succès (installation, réinstallation sans changement, désinstallation)
+#   1   échec (script cible absent, conflit de nom, aucun répertoire choisi)
+#   2   erreur d'usage (argument inconnu ou valeur manquante)
+#
+set -euo pipefail
+
+INSTALLER_NAME="$(basename "${BASH_SOURCE[0]}")"
+INSTALLER_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+TARGET_SCRIPT="$INSTALLER_DIR/pim-activate.sh"
+LINK_NAME="pim-activate"
+
+# Nom des répertoires bin utilisateur testés en priorité, dans cet ordre.
+PREFERRED_BIN_DIRS=("$HOME/.local/bin" "$HOME/bin")
+
+# Répertoire par défaut créé quand aucun candidat n'est dans $PATH.
+FALLBACK_BIN_DIR="$HOME/.local/bin"
+
+# Entrées de $PATH sous $HOME ignorées comme candidats : ce sont des dépôts
+# gérés par un outil (nvm, uv, dotnet…), pas des bin personnels.
+EXCLUDED_PATH_PATTERNS=(
+    "*/.nvm/*" "*/.cache/*" "*/.local/share/*" "*/.dotnet/*"
+    "*/node_modules/*" "*/.venv/*" "*/.rustup/*" "*/.cargo/*"
+)
+
+# Réutilise le menu clavier, err() et info() de pim-activate.sh plutôt que d'en
+# réécrire une variante. Le script cible est protégé par une garde de sourçage
+# ([[ ${BASH_SOURCE[0]} == $0 ]]) : le charger ne déclenche pas son main.
+if [[ ! -f "$TARGET_SCRIPT" ]]; then
+    printf "Erreur : script introuvable : %s\n" "$TARGET_SCRIPT" >&2
+    printf "Lancez %s depuis le dépôt, à côté de pim-activate.sh.\n" "$INSTALLER_NAME" >&2
+    exit 1
+fi
+# shellcheck source=pim-activate.sh
+source "$TARGET_SCRIPT"
+
+# Le sourçage a écrasé SCRIPT_NAME et usage() : on rétablit les nôtres.
+SCRIPT_NAME="$INSTALLER_NAME"
+
+usage() {
+    cat <<EOF
+Usage: $INSTALLER_NAME [--bin-dir RÉPERTOIRE] [--uninstall] [-h|--help]
+
+Installe « $LINK_NAME » dans un répertoire bin utilisateur de votre \$PATH, sous
+forme de lien symbolique vers :
+    $TARGET_SCRIPT
+
+Options :
+      --bin-dir DIR   Force le répertoire d'installation (aucun menu). Le
+                      répertoire est créé s'il manque ; s'il n'est pas dans
+                      \$PATH, la ligne d'export à ajouter est affichée.
+      --uninstall     Retire le lien « $LINK_NAME » posé par cet installeur.
+                      Un fichier qui n'est pas notre lien n'est jamais touché.
+  -h, --help          Affiche cette aide et quitte.
+
+Choix du répertoire :
+  Les candidats sont les répertoires bin utilisateur présents dans \$PATH
+  (~/.local/bin et ~/bin au minimum). Un seul candidat : il est retenu sans
+  question. Plusieurs : le menu clavier de pim-activate.sh vous fait choisir
+  (flèches ou numéro + Entrée, q pour annuler). Aucun : l'installeur propose de
+  créer $FALLBACK_BIN_DIR et affiche la ligne d'export à ajouter.
+
+Ce qui n'est jamais modifié :
+  Rien n'est écrit hors du répertoire bin retenu. Ni ~/.bashrc, ni ~/.profile,
+  ni ~/.zshrc ne sont touchés : la ligne d'export est seulement affichée. Aucun
+  sudo, aucune installation système.
+
+Idempotence :
+  Relancer l'installeur sur une installation déjà en place ne change rien et
+  sort en 0. Un fichier existant portant le nom « $LINK_NAME » et qui n'est pas
+  un lien vers ce script fait échouer l'installation, sans écrasement.
+
+Exemples :
+  ./$INSTALLER_NAME                       # détection puis installation
+  ./$INSTALLER_NAME --bin-dir ~/bin       # cible imposée, sans menu
+  ./$INSTALLER_NAME --uninstall           # retire le lien
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Répertoires : $PATH et candidats
+# ---------------------------------------------------------------------------
+
+# Découpe $PATH en tableau. `read -ra` plutôt qu'un `for` sur $PATH non quoté :
+# pas de glob involontaire sur une entrée contenant * ou ?.
+path_entries() {
+    local -a entries=()
+    IFS=: read -r -a entries <<<"$PATH"
+    printf '%s\n' "${entries[@]}"
+}
+
+# Vrai si $1 est une entrée de $PATH. Comparaison sur le chemin sans / final :
+# « ~/bin » et « ~/bin/ » désignent le même répertoire.
+path_contains() {
+    local wanted="${1%/}" entry
+    while IFS= read -r entry; do
+        [[ -n "$entry" ]] || continue
+        [[ "${entry%/}" == "$wanted" ]] && return 0
+    done < <(path_entries)
+    return 1
+}
+
+is_excluded_path() {
+    local dir="$1" pattern
+    for pattern in "${EXCLUDED_PATH_PATTERNS[@]}"; do
+        # shellcheck disable=SC2053  # glob volontaire à droite
+        [[ "$dir/" == $pattern ]] && return 0
+    done
+    return 1
+}
+
+# Répertoires bin utilisateur présents dans $PATH, dans l'ordre de préférence :
+# d'abord ~/.local/bin et ~/bin, puis les autres entrées de $PATH sous $HOME
+# qui ressemblent à un bin personnel. Un candidat peut ne pas exister encore
+# (déclaré dans le rc mais jamais créé) : il sera créé s'il est retenu.
+collect_candidate_dirs() {
+    local -a found=()
+    local dir entry seen
+
+    for dir in "${PREFERRED_BIN_DIRS[@]}"; do
+        path_contains "$dir" && found+=("${dir%/}")
+    done
+
+    while IFS= read -r entry; do
+        [[ -n "$entry" ]] || continue
+        entry="${entry%/}"
+        [[ "$entry" == "$HOME/"* ]] || continue
+        [[ "$entry" == */bin ]] || continue
+        is_excluded_path "$entry" && continue
+        for seen in "${found[@]}"; do
+            [[ "$seen" == "$entry" ]] && continue 2
+        done
+        found+=("$entry")
+    done < <(path_entries)
+
+    (( ${#found[@]} > 0 )) && printf '%s\n' "${found[@]}"
+    return 0
+}
+
+# Libellé de menu : le répertoire, plus son état (existant, à créer, déjà
+# occupé par un autre fichier).
+dir_label() {
+    local dir="$1" link="$1/$LINK_NAME"
+    if [[ ! -d "$dir" ]]; then
+        printf '%s  (à créer)' "$dir"
+    elif [[ -e "$link" || -L "$link" ]]; then
+        printf '%s  (contient déjà un fichier %s)' "$dir" "$LINK_NAME"
+    elif [[ ! -w "$dir" ]]; then
+        printf '%s  (non inscriptible)' "$dir"
+    else
+        printf '%s' "$dir"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Liens : reconnaissance de ce que l'installeur a posé
+# ---------------------------------------------------------------------------
+
+target_real_path() {
+    readlink -f "$TARGET_SCRIPT" 2>/dev/null || printf '%s' "$TARGET_SCRIPT"
+}
+
+# Vrai si $1 est un lien symbolique qui aboutit à pim-activate.sh — c'est-à-dire
+# un lien que cet installeur a posé (ou l'équivalent exact).
+is_our_link() {
+    local candidate="$1" resolved
+    [[ -L "$candidate" ]] || return 1
+    resolved="$(readlink -f "$candidate" 2>/dev/null || true)"
+    [[ -n "$resolved" && "$resolved" == "$(target_real_path)" ]]
+}
+
+# Répertoires de $PATH (plus les candidats, même hors $PATH) contenant déjà un
+# fichier nommé $LINK_NAME. Sortie : « mine|dir » ou « foreign|dir ».
+scan_installed_links() {
+    local -a dirs=()
+    local dir seen link
+
+    while IFS= read -r dir; do
+        [[ -n "$dir" ]] && dirs+=("${dir%/}")
+    done < <(path_entries; collect_candidate_dirs)
+
+    for dir in "${dirs[@]}"; do
+        link="$dir/$LINK_NAME"
+        [[ -e "$link" || -L "$link" ]] || continue
+        for seen in "${_scan_seen[@]-}"; do
+            [[ "$seen" == "$dir" ]] && continue 2
+        done
+        _scan_seen+=("$dir")
+        if is_our_link "$link"; then
+            printf 'mine|%s\n' "$dir"
+        else
+            printf 'foreign|%s\n' "$dir"
+        fi
+    done
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Choix du répertoire
+# ---------------------------------------------------------------------------
+
+# Menu oui/non bâti sur select_from_menu : même composant que le reste, pas de
+# prompt ad hoc. Retour 0 = oui.
+confirm_menu() {
+    local prompt="$1" yes_label="$2" no_label="$3" choice rc=0
+    choice="$(select_from_menu "$prompt" "$yes_label" "$no_label")" || rc=$?
+    (( rc == 0 )) || return 1
+    (( choice == 0 ))
+}
+
+# Écrit le répertoire retenu sur stdout. Retour 1 si l'utilisateur renonce.
+choose_bin_dir() {
+    local -a candidates=() labels=()
+    local dir choice rc=0
+
+    while IFS= read -r dir; do
+        [[ -n "$dir" ]] && candidates+=("$dir")
+    done < <(collect_candidate_dirs)
+
+    case ${#candidates[@]} in
+        0)
+            info "Aucun répertoire bin utilisateur n'est présent dans votre \$PATH."
+            if ! confirm_menu "Créer $FALLBACK_BIN_DIR et y installer $LINK_NAME ?" \
+                "Créer $FALLBACK_BIN_DIR" "Annuler l'installation"; then
+                return 1
+            fi
+            printf '%s\n' "$FALLBACK_BIN_DIR"
+            ;;
+        1)
+            info "Répertoire retenu (seul candidat dans \$PATH) : ${candidates[0]}"
+            printf '%s\n' "${candidates[0]}"
+            ;;
+        *)
+            for dir in "${candidates[@]}"; do
+                labels+=("$(dir_label "$dir")")
+            done
+            choice="$(select_from_menu \
+                "Plusieurs répertoires bin sont dans votre \$PATH — où installer $LINK_NAME ?" \
+                "${labels[@]}")" || rc=$?
+            if (( rc != 0 )); then
+                return 1
+            fi
+            printf '%s\n' "${candidates[$choice]}"
+            ;;
+    esac
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Vérification finale
+# ---------------------------------------------------------------------------
+
+# `command -v` dans un shell neuf : le shell courant a pu mettre en cache
+# l'absence de la commande, un sous-shell bash refait la recherche dans $PATH.
+resolved_command_path() {
+    bash -c "command -v $LINK_NAME" 2>/dev/null || true
+}
+
+report_resolution() {
+    local expected="$1" resolved
+    resolved="$(resolved_command_path)"
+    if [[ -z "$resolved" ]]; then
+        info "Attention : « $LINK_NAME » n'est pas résolu par \$PATH pour l'instant."
+        info "Ouvrez un nouveau shell (ou ajoutez la ligne d'export ci-dessus) puis réessayez."
+        return 0
+    fi
+    if [[ -n "$expected" && "$resolved" != "$expected" ]]; then
+        info "Attention : \$PATH résout d'abord $resolved, pas $expected."
+    fi
+    info "command -v $LINK_NAME → $resolved"
+    return 0
+}
+
+print_export_hint() {
+    local dir="$1"
+    info ""
+    info "$dir n'est pas dans votre \$PATH. Ajoutez cette ligne à votre shell rc"
+    info "(~/.bashrc, ~/.profile ou ~/.zshrc) — l'installeur n'y touche pas :"
+    info ""
+    printf '    export PATH="%s:$PATH"\n' "$dir" >&2
+    info ""
+    info "Puis rechargez le shell : source ~/.bashrc"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Actions
+# ---------------------------------------------------------------------------
+
+do_install() {
+    local requested_dir="$1"
+    local dir link entry state existing=""
+
+    if [[ ! -x "$TARGET_SCRIPT" ]]; then
+        info "Attention : $TARGET_SCRIPT n'est pas exécutable."
+        info "Corrigez-le avec : chmod +x $TARGET_SCRIPT"
+    fi
+
+    # Déjà installé ? On ne repose rien et on ne pose surtout pas de question :
+    # c'est ce qui rend une relance idempotente.
+    while IFS='|' read -r state entry; do
+        [[ "$state" == "mine" ]] || continue
+        if [[ -z "$requested_dir" || "${requested_dir%/}" == "$entry" ]]; then
+            existing="$entry"
+            break
+        fi
+    done < <(scan_installed_links)
+
+    if [[ -n "$existing" ]]; then
+        info "Déjà installé : $existing/$LINK_NAME → $(target_real_path)"
+        info "Rien à faire."
+        path_contains "$existing" || print_export_hint "$existing"
+        report_resolution "$existing/$LINK_NAME"
+        return 0
+    fi
+
+    if [[ -n "$requested_dir" ]]; then
+        dir="${requested_dir%/}"
+        [[ "$dir" == /* ]] || dir="$(cd -- "$(dirname -- "$dir")" 2>/dev/null && pwd -P)/$(basename -- "$dir")" || dir="$requested_dir"
+    else
+        dir="$(choose_bin_dir)" || {
+            err "Aucun répertoire choisi — rien n'a été installé."
+            return 1
+        }
+    fi
+
+    if [[ ! -d "$dir" ]]; then
+        info "Création de $dir"
+        mkdir -p -- "$dir"
+    fi
+    if [[ ! -w "$dir" ]]; then
+        err "Répertoire non inscriptible : $dir"
+        return 1
+    fi
+
+    link="$dir/$LINK_NAME"
+    if [[ -e "$link" || -L "$link" ]]; then
+        # Un lien à nous a déjà été traité plus haut : ici, c'est forcément un
+        # autre fichier. On refuse plutôt que d'écraser le travail d'autrui.
+        if [[ -L "$link" ]]; then
+            err "$link est déjà un lien vers $(readlink -f "$link" 2>/dev/null || readlink "$link"), pas vers $TARGET_SCRIPT."
+        else
+            err "$link existe déjà et n'est pas un lien symbolique."
+        fi
+        err "Rien n'a été écrasé. Retirez ce fichier vous-même, ou choisissez un autre répertoire (--bin-dir)."
+        return 1
+    fi
+
+    ln -s -- "$TARGET_SCRIPT" "$link"
+    info "Lien posé : $link → $TARGET_SCRIPT"
+
+    path_contains "$dir" || print_export_hint "$dir"
+    report_resolution "$link"
+    return 0
+}
+
+do_uninstall() {
+    local requested_dir="$1"
+    local state entry link removed=0 foreign=0
+
+    while IFS='|' read -r state entry; do
+        link="$entry/$LINK_NAME"
+        if [[ -n "$requested_dir" && "${requested_dir%/}" != "$entry" ]]; then
+            continue
+        fi
+        case "$state" in
+            mine)
+                rm -- "$link"
+                info "Lien retiré : $link"
+                removed=$(( removed + 1 ))
+                ;;
+            foreign)
+                info "Ignoré (pas un lien posé par cet installeur) : $link"
+                foreign=$(( foreign + 1 ))
+                ;;
+        esac
+    done < <(scan_installed_links)
+
+    if (( removed == 0 )); then
+        if (( foreign > 0 )); then
+            info "Aucun lien de cet installeur n'a été trouvé — rien n'a été retiré."
+        else
+            info "Rien à retirer : $LINK_NAME n'est pas installé."
+        fi
+        return 0
+    fi
+
+    # Contrôle du résultat : après retrait, plus rien ne doit répondre au nom.
+    local resolved
+    resolved="$(resolved_command_path)"
+    if [[ -n "$resolved" ]]; then
+        info "Attention : \$PATH résout encore $LINK_NAME → $resolved (autre installation)."
+    else
+        info "command -v $LINK_NAME → (rien)"
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Entrée
+# ---------------------------------------------------------------------------
+
+main() {
+    local action="install" bin_dir=""
+
+    while (( $# > 0 )); do
+        case "$1" in
+            -h|--help) usage; return 0 ;;
+            --uninstall) action="uninstall" ;;
+            --bin-dir)
+                if (( $# < 2 )); then
+                    err "--bin-dir attend un répertoire."
+                    return 2
+                fi
+                bin_dir="$2"
+                shift
+                ;;
+            --bin-dir=*) bin_dir="${1#*=}" ;;
+            --) shift; break ;;
+            *)
+                err "Argument inconnu : $1"
+                info "Lancez « $INSTALLER_NAME --help » pour l'aide."
+                return 2
+                ;;
+        esac
+        shift
+    done
+
+    # Le menu bascule le terminal en raw : on réutilise les traps du script
+    # cible pour ne pas laisser un terminal muet derrière nous.
+    install_signal_traps
+    trap restore_terminal_state EXIT
+
+    # Tableau consommé par scan_installed_links pour dédoublonner $PATH.
+    _scan_seen=()
+
+    case "$action" in
+        install) do_install "$bin_dir" ;;
+        uninstall) do_uninstall "$bin_dir" ;;
+    esac
+}
+
+main "$@"

--- a/pimMe/pim-activate.sh
+++ b/pimMe/pim-activate.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+#
+# pim-activate.sh — Activation interactive de rôles PIM Azure / Entra ID.
+#
+# Alternative rapide au portail pour activer un rôle éligible : liste les rôles
+# activables de l'utilisateur connecté, en sélectionne un au clavier, et soumet
+# la demande d'activation.
+#
+# Usage :
+#   ./pim-activate.sh [-s|--scope azure|entra] [-h|--help]
+#
+#   -s, --scope   Périmètre des rôles à lister : azure (rôles de ressources
+#                 Azure) ou entra (rôles d'annuaire Entra ID). Défaut : azure.
+#   -h, --help    Affiche l'aide et quitte.
+#
+# Prérequis :
+#   - bash 4+ (tableaux, read -rsn1) — pas de compatibilité sh POSIX visée
+#   - az   : Azure CLI, avec une session active (`az login` au préalable ;
+#            le script ne déclenche jamais de login automatique)
+#   - jq   : parsing des réponses JSON
+#
+# Codes de sortie :
+#   0   succès
+#   1   prérequis manquant ou session Azure absente/illisible
+#   2   erreur d'usage (argument inconnu ou valeur invalide)
+#
+# Note : $MENU_CANCELLED (64) est un retour de fonction interne, pas un code de
+# sortie du script — voir select_from_menu.
+#
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+
+# Durée d'activation par défaut (heures), utilisée par le flux d'activation
+# (goal 3) lorsque la politique PIM n'expose pas de maximum exploitable.
+# Voir plan.md — hypothèse à ajuster selon le tenant.
+DEFAULT_DURATION_HOURS=8
+
+# Périmètre courant : azure | entra. Bascule à chaud prévue au goal 2.
+SCOPE="azure"
+
+MENU_HINT="Flèches haut/bas + Entrée, numéro + Entrée, q pour annuler : "
+
+# Code de retour de select_from_menu quand l'utilisateur annule (q ou EOF).
+# Volontairement hors de la plage réservée par le shell : 126/127 (commande
+# non exécutable/introuvable) et surtout 128+N pour les signaux — 130 = SIGINT.
+# Le trap Ctrl+C du goal 4 doit rester distinguable d'une annulation de menu.
+MENU_CANCELLED=64
+
+usage() {
+    cat <<EOF
+Usage: $SCRIPT_NAME [-s|--scope azure|entra] [-h|--help]
+
+Activation interactive de rôles PIM (rôles de ressources Azure et rôles
+d'annuaire Entra ID), en alternative au portail.
+
+Options:
+  -s, --scope SCOPE   Périmètre des rôles : azure ou entra (défaut: ${SCOPE})
+  -h, --help          Affiche cette aide et quitte
+
+Prérequis:
+  az connecté (az login) et jq disponibles dans le PATH.
+
+Exemples:
+  $SCRIPT_NAME
+  $SCRIPT_NAME --scope entra
+EOF
+}
+
+err() {
+    printf "Erreur : %s\n" "$*" >&2
+}
+
+info() {
+    printf "%s\n" "$*" >&2
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || {
+        err "Commande requise introuvable : $1. Installez-la puis réessayez."
+        return 1
+    }
+}
+
+require_dependencies() {
+    local cmd
+    for cmd in az jq; do
+        require_command "$cmd" || return 1
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Menu interactif réutilisable
+#
+#   if index="$(select_from_menu "Titre" "opt 1" "opt 2" ...)"; then
+#       printf 'choisi : %s\n' "$index"
+#   else
+#       (( $? == MENU_CANCELLED )) && printf 'annulé\n'
+#   fi
+#
+# Rend le menu sur stderr, écrit l'index sélectionné (0-based) sur stdout.
+# Navigation : flèches haut/bas (avec bouclage) + Entrée, ou saisie directe
+# d'un numéro 1-based + Entrée. Backspace corrige la saisie.
+# 'q' ou EOF annule sans sélection : rien sur stdout, retour $MENU_CANCELLED.
+# Ce sentinel évite la plage 128+N des signaux, pour qu'un Ctrl+C intercepté
+# par un trap (goal 4) reste distinguable d'une annulation volontaire.
+# Bash pur — aucune dépendance externe (pas de fzf).
+# ---------------------------------------------------------------------------
+
+_menu_render() {
+    local count=${#_menu_options[@]}
+    local i line
+
+    if (( _menu_drawn )); then
+        # Hors terminal (pipe, test) le curseur n'est pas adressable :
+        # on rend une seule fois plutôt que d'empiler des redraws.
+        [[ -t 2 ]] || return 0
+        printf '\033[%dA\r\033[J' "$((count + 1))" >&2
+    fi
+
+    printf '%s\n' "$_menu_prompt" >&2
+    for i in "${!_menu_options[@]}"; do
+        line="$(printf '%d) %s' "$((i + 1))" "${_menu_options[$i]}")"
+        if (( i == _menu_selected )); then
+            if [[ -t 2 ]]; then
+                printf '\033[7m> %s\033[0m\n' "$line" >&2
+            else
+                printf '> %s\n' "$line" >&2
+            fi
+        else
+            printf '  %s\n' "$line" >&2
+        fi
+    done
+    printf '%s%s' "$MENU_HINT" "$_menu_typed" >&2
+    _menu_drawn=1
+}
+
+select_from_menu() {
+    local _menu_prompt="$1"
+    shift
+    local _menu_options=("$@")
+    local _menu_selected=0
+    local _menu_typed=""
+    local _menu_drawn=0
+    local count=${#_menu_options[@]}
+    local key rest
+
+    if (( count == 0 )); then
+        err "select_from_menu : aucune option fournie"
+        return 1
+    fi
+
+    while true; do
+        _menu_render
+
+        # EOF (Ctrl-D) traité comme une annulation.
+        if ! IFS= read -rsn1 key; then
+            printf '\n' >&2
+            return "$MENU_CANCELLED"
+        fi
+
+        case "$key" in
+            $'\e')
+                # Séquence ANSI : ESC [ A (haut) / ESC [ B (bas).
+                rest=""
+                read -rsn2 -t 0.2 rest || rest=""
+                case "$rest" in
+                    '[A') _menu_selected=$(( (_menu_selected - 1 + count) % count )); _menu_typed="" ;;
+                    '[B') _menu_selected=$(( (_menu_selected + 1) % count )); _menu_typed="" ;;
+                esac
+                ;;
+            '')
+                # Entrée : valide la saisie numérique si présente, sinon le surlignage.
+                if [[ -n "$_menu_typed" ]]; then
+                    if [[ "$_menu_typed" =~ ^[0-9]+$ ]] \
+                        && (( 10#$_menu_typed >= 1 && 10#$_menu_typed <= count )); then
+                        _menu_selected=$(( 10#$_menu_typed - 1 ))
+                    else
+                        # Hors borne : on efface la saisie et on redemande.
+                        _menu_typed=""
+                        continue
+                    fi
+                fi
+                break
+                ;;
+            [0-9])
+                _menu_typed+="$key"
+                ;;
+            $'\177'|$'\b')
+                _menu_typed="${_menu_typed%?}"
+                ;;
+            q|Q)
+                printf '\n' >&2
+                return "$MENU_CANCELLED"
+                ;;
+        esac
+    done
+
+    printf '\n' >&2
+    printf '%d\n' "$_menu_selected"
+}
+
+# ---------------------------------------------------------------------------
+# Arguments
+# ---------------------------------------------------------------------------
+
+validate_scope() {
+    case "$1" in
+        azure|entra) return 0 ;;
+        *)
+            err "Périmètre invalide : '$1' (valeurs attendues : azure, entra)"
+            return 1
+            ;;
+    esac
+}
+
+parse_args() {
+    while (( $# > 0 )); do
+        case "$1" in
+            -s|--scope)
+                [[ $# -ge 2 ]] || { err "Option $1 : valeur manquante"; return 2; }
+                SCOPE="$2"
+                shift 2
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            --)
+                shift
+                break
+                ;;
+            -*)
+                err "Option inconnue : $1"
+                usage >&2
+                return 2
+                ;;
+            *)
+                err "Argument inattendu : $1"
+                usage >&2
+                return 2
+                ;;
+        esac
+    done
+
+    validate_scope "$SCOPE" || return 2
+}
+
+# ---------------------------------------------------------------------------
+# Session Azure
+# ---------------------------------------------------------------------------
+
+AZ_ACCOUNT_JSON=""
+AZ_USER_NAME=""
+AZ_TENANT_ID=""
+
+# Vérifie qu'une session az est active. Ne déclenche jamais `az login` :
+# on informe et on sort, la décision de se connecter revient à l'utilisateur.
+check_azure_session() {
+    local az_err
+
+    az_err="$(mktemp)"
+    if ! AZ_ACCOUNT_JSON="$(az account show -o json 2>"$az_err")"; then
+        err "Aucune session Azure CLI active. Lancez 'az login' puis réessayez."
+        if [[ -s "$az_err" ]]; then
+            printf "Détail az : %s\n" "$(head -n 1 "$az_err")" >&2
+        fi
+        rm -f "$az_err"
+        return 1
+    fi
+    rm -f "$az_err"
+
+    if ! AZ_USER_NAME="$(jq -re '.user.name // empty' <<<"$AZ_ACCOUNT_JSON")"; then
+        err "Session Azure illisible : impossible de déterminer l'utilisateur connecté."
+        return 1
+    fi
+
+    if ! AZ_TENANT_ID="$(jq -re '.tenantId // empty' <<<"$AZ_ACCOUNT_JSON")"; then
+        err "Session Azure illisible : impossible de déterminer le tenant."
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Entrée
+# ---------------------------------------------------------------------------
+
+main() {
+    # Ordre volontaire : la validation des arguments précède tout contact avec
+    # az, pour que --help et une valeur invalide n'aient aucun coût réseau.
+    parse_args "$@" || return $?
+
+    require_dependencies || return 1
+    check_azure_session || return 1
+
+    info "Connecté en tant que ${AZ_USER_NAME} (tenant ${AZ_TENANT_ID})."
+    info "Périmètre courant : ${SCOPE}."
+    info "Socle prêt — le listing des rôles éligibles arrive au goal 2."
+}
+
+# Garde de sourçage : permet de charger le script pour tester select_from_menu
+# isolément sans exécuter main.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/pimMe/pim-activate.sh
+++ b/pimMe/pim-activate.sh
@@ -6,13 +6,12 @@
 # activables de l'utilisateur connecté, en sélectionne un au clavier, demande
 # une justification, soumet la demande d'activation et suit son statut jusqu'au
 # provisionnement — puis revient à la liste pour enchaîner une autre activation
-# sans relancer le script.
+# sans relancer le script. Seuls les rôles de ressources Azure sont gérés : les
+# rôles d'annuaire Entra ID sont hors périmètre.
 #
 # Usage :
-#   ./pim-activate.sh [-s|--scope azure] [-h|--help]
+#   ./pim-activate.sh [-h|--help]
 #
-#   -s, --scope   Périmètre des rôles à lister. Seule valeur supportée :
-#                 azure (rôles de ressources Azure). Défaut : azure.
 #   -h, --help    Affiche l'aide détaillée et quitte.
 #
 # Fonctionnement :
@@ -41,7 +40,7 @@
 # Codes de sortie :
 #   0   succès (y compris sortie volontaire par q)
 #   1   prérequis manquant ou session Azure absente/illisible
-#   2   erreur d'usage (argument inconnu ou valeur invalide)
+#   2   erreur d'usage (argument inconnu)
 #
 # Note : $MENU_CANCELLED (64) et $ACTIVATION_INTERRUPTED (65) sont des retours
 # de fonction internes, pas des codes de sortie du script.
@@ -55,11 +54,6 @@ SCRIPT_NAME="$(basename "$0")"
 # un refus de la politique est diagnostiqué par explain_az_error.
 # Voir plan.md — hypothèse à ajuster selon le tenant.
 DEFAULT_DURATION_HOURS=8
-
-# Périmètre courant. Seule valeur supportée : azure (le chemin Entra ID a été
-# retiré). L'option --scope reste acceptée pour rester explicite en ligne de
-# commande et pour ne pas casser les invocations existantes.
-SCOPE="azure"
 
 MENU_HINT="Flèches haut/bas + Entrée, numéro + Entrée, q pour annuler : "
 
@@ -95,17 +89,16 @@ MENU_HOTKEY_PRESSED=65
 
 usage() {
     cat <<EOF
-Usage: $SCRIPT_NAME [-s|--scope azure] [-h|--help]
+Usage: $SCRIPT_NAME [-h|--help]
 
 Activation interactive de rôles PIM de ressources Azure, en alternative au
 portail. Le script liste les rôles éligibles de l'utilisateur connecté, en
 active un après saisie d'une justification, suit le provisionnement, puis
-revient à la liste rafraîchie pour enchaîner sans redémarrer.
+revient à la liste rafraîchie pour enchaîner sans redémarrer. Seuls les rôles
+de ressources Azure sont gérés : les rôles d'annuaire Entra ID sont hors
+périmètre.
 
 Options:
-  -s, --scope SCOPE   Périmètre des rôles. Seule valeur supportée : azure
-                      (défaut: ${SCOPE}). Les rôles d'annuaire Entra ID ne
-                      sont pas gérés.
   -h, --help          Affiche cette aide et quitte.
 
 Navigation dans la liste:
@@ -134,9 +127,6 @@ Limitations connues:
 Exemples:
   # Lister les rôles Azure éligibles et en activer un
   $SCRIPT_NAME
-
-  # Même chose, périmètre explicite
-  $SCRIPT_NAME --scope azure
 
   # Afficher cette aide
   $SCRIPT_NAME --help
@@ -368,24 +358,12 @@ select_from_menu() {
 # Arguments
 # ---------------------------------------------------------------------------
 
-validate_scope() {
-    case "$1" in
-        azure) return 0 ;;
-        *)
-            err "Périmètre invalide : '$1' (seule valeur supportée : azure)"
-            return 1
-            ;;
-    esac
-}
-
+# Le script n'a qu'un seul mode d'appel : pas d'option de périmètre, le
+# listing ARM est le seul chemin. Tout argument inconnu reste une erreur
+# d'usage (code 2) accompagnée de l'aide, plutôt qu'un silence.
 parse_args() {
     while (( $# > 0 )); do
         case "$1" in
-            -s|--scope)
-                [[ $# -ge 2 ]] || { err "Option $1 : valeur manquante"; return 2; }
-                SCOPE="$2"
-                shift 2
-                ;;
             -h|--help)
                 usage
                 exit 0
@@ -406,8 +384,6 @@ parse_args() {
                 ;;
         esac
     done
-
-    validate_scope "$SCOPE" || return 2
 }
 
 # ---------------------------------------------------------------------------
@@ -503,7 +479,7 @@ az_rest_get() {
     printf '%s' "$body"
 }
 
-# Tableaux parallèles décrivant les rôles du scope courant. Chaque entrée porte
+# Tableaux parallèles décrivant les rôles éligibles chargés. Chaque entrée porte
 # tout ce dont goal 3 a besoin pour construire la requête d'activation sans
 # re-quêter l'API (cf. contrainte du goal 2).
 ROLE_LABELS=()
@@ -567,23 +543,18 @@ list_azure_roles() {
     ' <<<"$body" | sort)
 }
 
-# Charge les rôles du scope demandé. Retour 0 = chargé (éventuellement vide),
+# Charge les rôles éligibles. Retour 0 = chargé (éventuellement vide),
 # 1 = échec d'appel.
 load_roles() {
-    local scope="$1"
-
     reset_roles
-    case "$scope" in
-        azure) list_azure_roles ;;
-        *) err "Scope inconnu : $scope"; return 1 ;;
-    esac
+    list_azure_roles
 }
 
 # ---------------------------------------------------------------------------
 # Navigation
 #
-# Choix d'implémentation pour la bascule de scope : plutôt que de dupliquer une
-# boucle de lecture clavier au-dessus du menu, select_from_menu accepte des
+# Choix d'implémentation pour les touches d'action (r) : plutôt que de dupliquer
+# une boucle de lecture clavier au-dessus du menu, select_from_menu accepte des
 # touches d'action ($MENU_HOTKEYS) et rend la main avec $MENU_HOTKEY_PRESSED en
 # écrivant la touche sur stdout. Une seule boucle de lecture, un seul rendu, et
 # le contrat du goal 1 reste intact quand MENU_HOTKEYS est vide.
@@ -626,11 +597,11 @@ browse_roles() {
     local selection rc
 
     while true; do
-        info "Chargement des rôles eligible (scope ${SCOPE})…"
+        info "Chargement des rôles eligible…"
         # `load_roles` échouant sous set -e sortirait du script avant tout
         # test : le code est capturé dans la même commande composée.
         rc=0
-        load_roles "$SCOPE" || rc=$?
+        load_roles || rc=$?
 
         # Une interruption pendant le chargement ne doit pas être lue comme un
         # échec d'API : on recharge simplement.
@@ -640,14 +611,14 @@ browse_roles() {
 
         if (( rc != 0 )); then
             info ""
-            info "Impossible de lister les rôles éligibles (scope ${SCOPE})."
+            info "Impossible de lister les rôles éligibles."
             prompt_retry_or_quit || return 0
             continue
         fi
 
         if (( ${#ROLE_LABELS[@]} == 0 )); then
             info ""
-            info "Aucun rôle eligible sur ce scope (${SCOPE})."
+            info "Aucun rôle eligible sur ce périmètre."
             prompt_retry_or_quit || return 0
             continue
         fi
@@ -657,7 +628,7 @@ browse_roles() {
         # on capture le code dans la même commande composée.
         rc=0
         selection="$(select_from_menu \
-            "Rôles ${SCOPE} eligible (${#ROLE_LABELS[@]}) — Entrée active, r recharge, q quitte :" \
+            "Rôles eligible (${#ROLE_LABELS[@]}) — Entrée active, r recharge, q quitte :" \
             "${ROLE_LABELS[@]}")" || rc=$?
         MENU_HOTKEYS=()
 
@@ -1086,16 +1057,8 @@ activate_role() {
 
     info ""
     info "Soumission de la demande (${DEFAULT_DURATION_HOURS}h)…"
-    case "$SCOPE" in
-        azure)
-            rc=0
-            submit_azure_activation "$index" || rc=$?
-            ;;
-        *)
-            err "Scope inconnu : $SCOPE"
-            return 1
-            ;;
-    esac
+    rc=0
+    submit_azure_activation "$index" || rc=$?
     if (( rc != 0 )); then
         # Une soumission interrompue au clavier a pu laisser le drapeau levé :
         # on le consomme ici pour que la liste ne reparte pas sur un faux signal.

--- a/pimMe/pim-activate.sh
+++ b/pimMe/pim-activate.sh
@@ -1,18 +1,26 @@
 #!/usr/bin/env bash
 #
-# pim-activate.sh — Activation interactive de rôles PIM Azure / Entra ID.
+# pim-activate.sh — Activation interactive de rôles PIM de ressources Azure.
 #
 # Alternative rapide au portail pour activer un rôle éligible : liste les rôles
 # activables de l'utilisateur connecté, en sélectionne un au clavier, demande
 # une justification, soumet la demande d'activation et suit son statut jusqu'au
-# provisionnement.
+# provisionnement — puis revient à la liste pour enchaîner une autre activation
+# sans relancer le script.
 #
 # Usage :
-#   ./pim-activate.sh [-s|--scope azure|entra] [-h|--help]
+#   ./pim-activate.sh [-s|--scope azure] [-h|--help]
 #
-#   -s, --scope   Périmètre des rôles à lister : azure (rôles de ressources
-#                 Azure) ou entra (rôles d'annuaire Entra ID). Défaut : azure.
-#   -h, --help    Affiche l'aide et quitte.
+#   -s, --scope   Périmètre des rôles à lister. Seule valeur supportée :
+#                 azure (rôles de ressources Azure). Défaut : azure.
+#   -h, --help    Affiche l'aide détaillée et quitte.
+#
+# Fonctionnement :
+#   1. liste des rôles Azure éligibles (scope racine, filtre asTarget) ;
+#   2. sélection au clavier (flèches ou numéro), r rafraîchit, q quitte ;
+#   3. justification saisie à l'écran, obligatoire sur les rôles sensibles ;
+#   4. soumission SelfActivate puis polling du statut jusqu'au provisionnement ;
+#   5. retour automatique à la liste rafraîchie, quel que soit le résultat.
 #
 # Prérequis :
 #   - bash 4+ (tableaux, read -rsn1) — pas de compatibilité sh POSIX visée
@@ -22,15 +30,22 @@
 #   - uuidgen (facultatif) : identifiant de la demande d'activation ARM ;
 #            repli automatique sur /proc/sys/kernel/random/uuid
 #
+# Limitations connues (cf. plan.md, section « hors scope ») :
+#   - pas de désactivation d'un rôle actif — passer par le portail ;
+#   - pas de gestion du workflow d'approbation : une demande en
+#     PendingApproval est affichée puis abandonnée au bout de 60s, elle
+#     continue d'être traitée côté portail ;
+#   - mono-tenant : le tenant est celui de la session az courante ;
+#   - rôles d'annuaire Entra ID non gérés (chemin Graph retiré).
+#
 # Codes de sortie :
-#   0   succès
+#   0   succès (y compris sortie volontaire par q)
 #   1   prérequis manquant ou session Azure absente/illisible
 #   2   erreur d'usage (argument inconnu ou valeur invalide)
 #
-# Note : $MENU_CANCELLED (64) est un retour de fonction interne, pas un code de
-# sortie du script — voir select_from_menu.
+# Note : $MENU_CANCELLED (64) et $ACTIVATION_INTERRUPTED (65) sont des retours
+# de fonction internes, pas des codes de sortie du script.
 #
-
 set -euo pipefail
 
 SCRIPT_NAME="$(basename "$0")"
@@ -41,7 +56,9 @@ SCRIPT_NAME="$(basename "$0")"
 # Voir plan.md — hypothèse à ajuster selon le tenant.
 DEFAULT_DURATION_HOURS=8
 
-# Périmètre courant : azure | entra. Bascule à chaud par les touches a/e.
+# Périmètre courant. Seule valeur supportée : azure (le chemin Entra ID a été
+# retiré). L'option --scope reste acceptée pour rester explicite en ligne de
+# commande et pour ne pas casser les invocations existantes.
 SCOPE="azure"
 
 MENU_HINT="Flèches haut/bas + Entrée, numéro + Entrée, q pour annuler : "
@@ -52,8 +69,24 @@ MENU_HINT="Flèches haut/bas + Entrée, numéro + Entrée, q pour annuler : "
 # Le trap Ctrl+C du goal 4 doit rester distinguable d'une annulation de menu.
 MENU_CANCELLED=64
 
-# Touches d'action passées au menu par l'appelant (goal 2 : a/e pour basculer
-# de scope). Vide par défaut : le contrat du goal 1 est inchangé.
+# Retour de fonction quand l'utilisateur interrompt (Ctrl+C) une saisie ou une
+# attente : l'appelant doit revenir à la liste, pas quitter. Comme
+# $MENU_CANCELLED, la valeur reste hors de la plage 128+N des signaux pour
+# rester distinguable d'une mort par signal.
+ACTIVATION_INTERRUPTED=65
+
+# Positionné par le trap SIGINT, consommé (et remis à 0) par les boucles qui
+# peuvent être interrompues. Un trap bash ne peut pas « casser » la boucle en
+# cours : il ne fait que lever ce drapeau, que les boucles testent.
+INTERRUPTED=0
+
+# Réglages tty d'origine, restaurés après une interruption : `read -rsn1` bascule
+# le terminal en raw/-echo, et une saisie tuée en plein vol laisserait sinon un
+# terminal muet ou sans curseur.
+SAVED_STTY=""
+
+# Touches d'action passées au menu par l'appelant (goal 4 : r pour recharger
+# la liste). Vide par défaut : le contrat du goal 1 est inchangé.
 MENU_HOTKEYS=()
 # Retour de select_from_menu quand une hotkey est pressée : la touche est
 # écrite sur stdout. Passer par stdout et non par une variable globale est
@@ -62,21 +95,54 @@ MENU_HOTKEY_PRESSED=65
 
 usage() {
     cat <<EOF
-Usage: $SCRIPT_NAME [-s|--scope azure|entra] [-h|--help]
+Usage: $SCRIPT_NAME [-s|--scope azure] [-h|--help]
 
-Activation interactive de rôles PIM (rôles de ressources Azure et rôles
-d'annuaire Entra ID), en alternative au portail.
+Activation interactive de rôles PIM de ressources Azure, en alternative au
+portail. Le script liste les rôles éligibles de l'utilisateur connecté, en
+active un après saisie d'une justification, suit le provisionnement, puis
+revient à la liste rafraîchie pour enchaîner sans redémarrer.
 
 Options:
-  -s, --scope SCOPE   Périmètre des rôles : azure ou entra (défaut: ${SCOPE})
-  -h, --help          Affiche cette aide et quitte
+  -s, --scope SCOPE   Périmètre des rôles. Seule valeur supportée : azure
+                      (défaut: ${SCOPE}). Les rôles d'annuaire Entra ID ne
+                      sont pas gérés.
+  -h, --help          Affiche cette aide et quitte.
+
+Navigation dans la liste:
+  Flèches haut/bas    Déplace la sélection
+  1..N puis Entrée    Sélectionne directement par numéro
+  Entrée              Active le rôle surligné
+  r                   Recharge la liste depuis l'API
+  q                   Quitte le script (code 0)
+  Ctrl+C              Annule la saisie ou l'attente en cours et revient
+                      à la liste ; ne quitte jamais brutalement
+
+Justification:
+  Une justification est proposée pré-remplie et éditable en place. Sur les
+  rôles sensibles (Owner, User Access Administrator) elle est obligatoire :
+  aucun texte n'est pré-rempli et une saisie vide est refusée.
 
 Prérequis:
   az connecté (az login) et jq disponibles dans le PATH.
 
+Limitations connues:
+  - pas de désactivation d'un rôle actif (portail) ;
+  - workflow d'approbation non géré : une demande PendingApproval est
+    affichée puis abandonnée après ${POLL_TIMEOUT_SECONDS}s de polling, sans être annulée ;
+  - mono-tenant : le tenant est celui de la session az courante.
+
 Exemples:
+  # Lister les rôles Azure éligibles et en activer un
   $SCRIPT_NAME
-  $SCRIPT_NAME --scope entra
+
+  # Même chose, périmètre explicite
+  $SCRIPT_NAME --scope azure
+
+  # Afficher cette aide
+  $SCRIPT_NAME --help
+
+Durée d'activation demandée : ${DEFAULT_DURATION_HOURS}h (constante DEFAULT_DURATION_HOURS
+en tête de script).
 EOF
 }
 
@@ -100,6 +166,64 @@ require_dependencies() {
     for cmd in az jq; do
         require_command "$cmd" || return 1
     done
+}
+
+# ---------------------------------------------------------------------------
+# Interruptions et état du terminal
+#
+# Un trap bash ne peut pas « casser » la boucle en cours : il lève un drapeau
+# ($INTERRUPTED) que les boucles interruptibles consomment via take_interrupt.
+# Les substitutions de commande (`x="$(select_from_menu …)"`, `az rest`) sont
+# des sous-shells, où bash réinitialise les traps aux valeurs par défaut : le
+# sous-shell meurt du signal et c'est le shell parent, lui trappé, qui lève le
+# drapeau. Chaque appelant en substitution constate donc l'interruption après
+# coup, sur son propre retour.
+# ---------------------------------------------------------------------------
+
+save_terminal_state() {
+    if [[ -t 0 ]]; then
+        SAVED_STTY="$(stty -g 2>/dev/null || true)"
+    fi
+    return 0
+}
+
+# Rend le terminal utilisable après une saisie tuée en plein vol : `read -rsn1`
+# l'a basculé en raw/-echo, et readline peut avoir masqué le curseur.
+restore_terminal_state() {
+    if [[ -n "$SAVED_STTY" && -t 0 ]]; then
+        stty "$SAVED_STTY" 2>/dev/null || true
+    fi
+    if [[ -t 2 ]]; then
+        printf '\033[?25h' >&2
+    fi
+    return 0
+}
+
+on_interrupt() {
+    INTERRUPTED=1
+    restore_terminal_state
+    printf '\n' >&2
+    info "Interruption (Ctrl+C) — retour à la liste."
+    return 0
+}
+
+# Consomme le drapeau : 0 si une interruption était en attente (et elle est
+# alors remise à zéro), 1 sinon. Un drapeau non consommé ferait traiter la même
+# interruption deux fois.
+take_interrupt() {
+    (( INTERRUPTED )) || return 1
+    INTERRUPTED=0
+    return 0
+}
+
+install_signal_traps() {
+    save_terminal_state
+    trap on_interrupt INT
+    # SIGTERM/SIGHUP ne sont pas rattrapables en « retour au menu » : on rend
+    # simplement le terminal avant de partir.
+    trap 'restore_terminal_state; exit 143' TERM
+    trap 'restore_terminal_state; exit 129' HUP
+    return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -179,8 +303,15 @@ select_from_menu() {
     while true; do
         _menu_render
 
-        # EOF (Ctrl-D) traité comme une annulation.
+        # EOF (Ctrl-D) traité comme une annulation. Une interruption, elle,
+        # ne fait que redemander une touche : le menu reste à l'écran.
+        # (Chemin utile quand le menu tourne dans le shell trappé ; en
+        # substitution de commande, c'est l'appelant qui constate le signal.)
         if ! IFS= read -rsn1 key; then
+            if take_interrupt; then
+                _menu_drawn=0
+                continue
+            fi
             printf '\n' >&2
             return "$MENU_CANCELLED"
         fi
@@ -239,9 +370,9 @@ select_from_menu() {
 
 validate_scope() {
     case "$1" in
-        azure|entra) return 0 ;;
+        azure) return 0 ;;
         *)
-            err "Périmètre invalide : '$1' (valeurs attendues : azure, entra)"
+            err "Périmètre invalide : '$1' (seule valeur supportée : azure)"
             return 1
             ;;
     esac
@@ -336,13 +467,11 @@ check_azure_session() {
 # la boucle par souscription).
 #
 # Les parenthèses de asTarget() DOIVENT être encodées en %28%29 : ARM répond
-# 400 "Bad Request - Invalid URL" sur les parenthèses brutes. Graph, lui, les
-# accepte telles quelles.
+# 400 "Bad Request - Invalid URL" sur les parenthèses brutes.
 # ---------------------------------------------------------------------------
 
 ARM_API_VERSION="2020-10-01"
 ARM_ELIGIBLE_URL="https://management.azure.com/providers/Microsoft.Authorization/roleEligibilityScheduleInstances?api-version=${ARM_API_VERSION}&\$filter=asTarget%28%29"
-GRAPH_ELIGIBLE_URL="https://graph.microsoft.com/v1.0/roleManagement/directory/roleEligibilityScheduleInstances/filterByCurrentUser(on='principal')?%24expand=roleDefinition"
 
 # Dernière erreur brute renvoyée par az rest, pour un diagnostic exploitable.
 # Stockée dans un FICHIER et non dans une variable : les appelants invoquent
@@ -352,7 +481,7 @@ AZ_REST_ERROR_FILE=""
 
 init_az_rest_error_file() {
     AZ_REST_ERROR_FILE="$(mktemp)"
-    trap 'rm -f "$AZ_REST_ERROR_FILE"' EXIT
+    trap 'rm -f "$AZ_REST_ERROR_FILE"; restore_terminal_state' EXIT
 }
 
 az_rest_last_error() {
@@ -381,24 +510,31 @@ ROLE_LABELS=()
 ROLE_DEFINITION_IDS=()
 ROLE_SCOPES=()
 ROLE_SCHEDULE_IDS=()
+# Nom brut du rôle, séparé du libellé d'affichage (qui y colle le scope) :
+# la règle de justification obligatoire s'y adosse sans découper une chaîne
+# destinée à l'œil.
+ROLE_NAMES=()
 
 reset_roles() {
     ROLE_LABELS=()
     ROLE_DEFINITION_IDS=()
     ROLE_SCOPES=()
     ROLE_SCHEDULE_IDS=()
+    ROLE_NAMES=()
 }
 
-# Alimente les tableaux depuis un flux TSV « label \t defId \t scope \t schedId ».
+# Alimente les tableaux depuis un flux TSV
+# « label \t defId \t scope \t schedId \t nom ».
 # Le TSV vient exclusivement de `jq -r ... | @tsv` : aucune regex sur du JSON.
 ingest_roles_tsv() {
-    local label def_id scope sched_id
-    while IFS=$'\t' read -r label def_id scope sched_id; do
+    local label def_id scope sched_id name
+    while IFS=$'\t' read -r label def_id scope sched_id name; do
         [[ -n "$label" ]] || continue
         ROLE_LABELS+=("$label")
         ROLE_DEFINITION_IDS+=("$def_id")
         ROLE_SCOPES+=("$scope")
         ROLE_SCHEDULE_IDS+=("$sched_id")
+        ROLE_NAMES+=("$name")
     done
 }
 
@@ -424,32 +560,8 @@ list_azure_roles() {
               + ($i.properties.expandedProperties.scope.displayName // $i.properties.scope) ),
             $i.properties.roleDefinitionId,
             $i.properties.scope,
-            $i.properties.roleEligibilityScheduleId
-          ]
-        | @tsv
-    ' <<<"$body" | sort)
-}
-
-list_entra_roles() {
-    local body
-
-    if ! body="$(az_rest_get "$GRAPH_ELIGIBLE_URL")"; then
-        err "Échec de la récupération des rôles Entra eligible."
-        explain_az_error
-        return 1
-    fi
-
-    # Pour Entra, directoryScopeId tient le rôle du scope ARM ; "/" = tenant.
-    ingest_roles_tsv < <(jq -r '
-        .value[]
-        | . as $i
-        | [
-            ( ($i.roleDefinition.displayName // $i.roleDefinitionId)
-              + "  —  annuaire "
-              + (if ($i.directoryScopeId // "/") == "/" then "tenant" else $i.directoryScopeId end) ),
-            $i.roleDefinitionId,
-            ($i.directoryScopeId // "/"),
-            $i.id
+            $i.properties.roleEligibilityScheduleId,
+            ($i.properties.expandedProperties.roleDefinition.displayName // "")
           ]
         | @tsv
     ' <<<"$body" | sort)
@@ -463,7 +575,6 @@ load_roles() {
     reset_roles
     case "$scope" in
         azure) list_azure_roles ;;
-        entra) list_entra_roles ;;
         *) err "Scope inconnu : $scope"; return 1 ;;
     esac
 }
@@ -478,10 +589,6 @@ load_roles() {
 # le contrat du goal 1 reste intact quand MENU_HOTKEYS est vide.
 # ---------------------------------------------------------------------------
 
-other_scope() {
-    [[ "$1" == "azure" ]] && printf 'entra' || printf 'azure'
-}
-
 # Récapitulatif du rôle choisi, affiché juste avant le prompt de justification.
 show_selection() {
     local index="$1"
@@ -493,60 +600,85 @@ show_selection() {
     printf '  schedule eligible    : %s\n' "${ROLE_SCHEDULE_IDS[$index]}" >&2
 }
 
-# Boucle de listing : affiche le scope courant, bascule sur a/e, sort sur q ou
-# sélection. La boucle complète post-activation appartient au goal 4.
+# Après une liste vide ou un échec d'appel : recharger ou quitter. Sans ce
+# point d'arrêt, « revenir à la liste » sur une erreur persistante (réseau
+# coupé, droits manquants) boucle indéfiniment sans jamais rendre la main.
+prompt_retry_or_quit() {
+    local answer rc=0
+
+    # Substitution de commande obligatoire ici aussi : cf. _read_line_edited.
+    answer="$(_read_line_edited "" "Recharger la liste ? [O/n] ")" || rc=$?
+    if (( rc != 0 )); then
+        # Ctrl+C ou EOF sur cette question : on ne relance pas une liste qui
+        # vient d'échouer, on rend la main.
+        take_interrupt || printf '\n' >&2
+        return 1
+    fi
+    [[ ! "$answer" =~ ^[[:space:]]*[nNqQ] ]]
+}
+
+# Boucle principale : liste → sélection → activation → retour à la liste
+# rafraîchie, indéfiniment. Aucun retour d'activate_role ne quitte le script :
+# succès, échec API et annulation ramènent tous à la liste. Seules sorties :
+# `q` au menu (code 0), refus de recharger après un échec, ou une erreur fatale
+# de session détectée par main.
 browse_roles() {
-    local selection rc target
+    local selection rc
 
     while true; do
         info "Chargement des rôles eligible (scope ${SCOPE})…"
-        if ! load_roles "$SCOPE"; then
-            target="$(other_scope "$SCOPE")"
+        # `load_roles` échouant sous set -e sortirait du script avant tout
+        # test : le code est capturé dans la même commande composée.
+        rc=0
+        load_roles "$SCOPE" || rc=$?
+
+        # Une interruption pendant le chargement ne doit pas être lue comme un
+        # échec d'API : on recharge simplement.
+        if take_interrupt; then
+            continue
+        fi
+
+        if (( rc != 0 )); then
             info ""
-            info "Impossible de lister le scope ${SCOPE}."
-            if ! prompt_scope_switch "$target"; then
-                return 1
-            fi
-            SCOPE="$target"
+            info "Impossible de lister les rôles éligibles (scope ${SCOPE})."
+            prompt_retry_or_quit || return 0
             continue
         fi
 
         if (( ${#ROLE_LABELS[@]} == 0 )); then
-            target="$(other_scope "$SCOPE")"
             info ""
             info "Aucun rôle eligible sur ce scope (${SCOPE})."
-            if ! prompt_scope_switch "$target"; then
-                return 0
-            fi
-            SCOPE="$target"
+            prompt_retry_or_quit || return 0
             continue
         fi
 
-        MENU_HOTKEYS=("a" "e")
+        MENU_HOTKEYS=("r")
         # `x="$(cmd)"` qui échoue sort du script sous set -e avant tout rc=$? :
         # on capture le code dans la même commande composée.
         rc=0
         selection="$(select_from_menu \
-            "Rôles ${SCOPE} eligible (${#ROLE_LABELS[@]}) — a=azure e=entra q=quitter :" \
+            "Rôles ${SCOPE} eligible (${#ROLE_LABELS[@]}) — Entrée active, r recharge, q quitte :" \
             "${ROLE_LABELS[@]}")" || rc=$?
         MENU_HOTKEYS=()
 
+        # Ctrl+C au clavier : le menu tourne dans un sous-shell de
+        # substitution, aux traps réinitialisés — il meurt du signal (rc 130)
+        # et c'est ici, dans le shell parent trappé, qu'on le constate.
+        if take_interrupt || (( rc > 128 )); then
+            continue
+        fi
+
         case $rc in
             0)
-                # `cmd; return $?` ne suffit pas sous set -e : un échec de
-                # activate_role sortirait du script avant le return.
-                rc=0
-                activate_role "$selection" || rc=$?
-                return "$rc"
+                # Tout retour ramène à la liste : un échec d'activation n'est
+                # pas une raison de quitter (goal 4, gestion d'erreurs globale).
+                activate_role "$selection" || true
                 ;;
             "$MENU_HOTKEY_PRESSED")
-                case "$selection" in
-                    a) SCOPE="azure" ;;
-                    e) SCOPE="entra" ;;
-                esac
+                # Seule hotkey déclarée : r = recharger la liste.
                 ;;
             "$MENU_CANCELLED")
-                info "Annulé."
+                info "Sortie."
                 return 0
                 ;;
             *)
@@ -555,14 +687,6 @@ browse_roles() {
                 ;;
         esac
     done
-}
-
-# Propose de basculer vers l'autre scope quand le courant est vide ou en échec.
-prompt_scope_switch() {
-    local target="$1" answer
-
-    read -r -p "Basculer vers le scope ${target} ? [o/N] " answer || return 1
-    [[ "$answer" =~ ^[oOyY]$ ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -584,16 +708,48 @@ prompt_scope_switch() {
 # Placeholder « business » proposé à l'écran, éditable avant validation.
 DEFAULT_JUSTIFICATION="Intervention support — troubleshooting"
 
+# Rôles sensibles : justification obligatoire, non vide, et surtout AUCUN texte
+# pré-rempli — un placeholder validé d'un coup d'Entrée ne documente rien et
+# c'est précisément sur ces deux rôles que la trace doit être réelle.
+# Reconnaissance par GUID de rôle intégré (stable, indépendant de la langue du
+# tenant) ET par nom, au cas où l'API ne renvoie pas le displayName attendu.
+STRICT_JUSTIFICATION_ROLE_GUIDS=(
+    "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"  # Owner
+    "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9"  # User Access Administrator
+)
+STRICT_JUSTIFICATION_ROLE_NAMES=(
+    "owner"
+    "user access administrator"
+)
+
 # Polling du statut de la demande. Pas de workflow d'approbation en v1
 # (cf. plan.md) : on affiche l'état et on sort au bout du timeout.
 POLL_INTERVAL_SECONDS=4
 POLL_TIMEOUT_SECONDS=60
 
-GRAPH_REQUESTS_URL="https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignmentScheduleRequests"
-
 AZ_PRINCIPAL_ID=""
 JUSTIFICATION=""
 POLL_URL=""
+
+# 0 = le rôle d'indice $1 exige une justification saisie à la main.
+justification_is_mandatory() {
+    local index="$1" guid name candidate
+
+    name="${ROLE_NAMES[$index]:-}"
+    name="${name,,}"
+    for candidate in "${STRICT_JUSTIFICATION_ROLE_NAMES[@]}"; do
+        [[ "$name" == "$candidate" ]] && return 0
+    done
+
+    # roleDefinitionId ARM = .../roleDefinitions/{guid} : seul le GUID compte.
+    guid="${ROLE_DEFINITION_IDS[$index]##*/}"
+    guid="${guid,,}"
+    for candidate in "${STRICT_JUSTIFICATION_ROLE_GUIDS[@]}"; do
+        [[ "$guid" == "$candidate" ]] && return 0
+    done
+
+    return 1
+}
 
 # Traduit les erreurs az récurrentes en message actionnable, puis affiche le
 # détail brut. Partagé par le listing et l'activation.
@@ -604,8 +760,8 @@ explain_az_error() {
     case "$raw" in
         *PermissionScopeNotGranted*)
             err "L'application Azure CLI n'a pas les permissions Graph requises sur ce tenant."
-            err "Un administrateur doit consentir RoleManagement.Read.Directory (ou"
-            err "RoleEligibilitySchedule.Read.Directory) pour l'app 04b07795-8ddb-461a-bbee-02f9e1bf7b46."
+            err "Seul le repli de résolution de l'objectId (az ad signed-in-user show) en"
+            err "dépend : le listing et l'activation n'appellent que l'API ARM."
             ;;
         *AADSTS70043*|*token_expired*|*invalid_grant*)
             err "Session Azure CLI expirée (sign-in frequency de l'accès conditionnel)."
@@ -613,11 +769,22 @@ explain_az_error() {
             ;;
         *AADSTS50076*|*AADSTS50079*|*MFA*|*mfa*|*claims*)
             err "Ce rôle exige une authentification forte (MFA) récente."
-            err "Relancez 'az login --scope https://graph.microsoft.com//.default' puis réessayez."
+            err "Relancez 'az login --tenant ${AZ_TENANT_ID:-<tenant>}' en validant le"
+            err "second facteur, puis réessayez."
+            ;;
+        *RoleAssignmentExists*|*RoleAssignmentRequestExists*)
+            err "Ce rôle est déjà actif (ou une demande est déjà en cours) sur ce scope."
+            err "Attendez son expiration ou désactivez-le dans le portail PIM."
             ;;
         *RoleAssignmentRequestPolicyValidationFailed*|*MaximumDuration*|*maximum*duration*)
             err "Durée demandée refusée par la politique PIM du rôle."
             err "Baissez DEFAULT_DURATION_HOURS (actuellement ${DEFAULT_DURATION_HOURS}h) en tête de script."
+            ;;
+        *"Connection aborted"*|*"Max retries exceeded"*|*"Failed to establish a new connection"*|\
+        *"Name or service not known"*|*"Temporary failure in name resolution"*|\
+        *"Read timed out"*|*"ConnectionError"*|*"SSLError"*|*"Network is unreachable"*)
+            err "Appel Azure impossible : le réseau ou le service ne répond pas."
+            err "Vérifiez la connectivité (proxy, VPN, DNS) puis rechargez la liste."
             ;;
     esac
 
@@ -668,29 +835,87 @@ resolve_principal_id() {
     fi
 }
 
-# Saisie pré-remplie et éditable en place (readline). Entrée valide le texte
-# affiché à l'écran : le placeholder ne part jamais sans ce passage explicite.
-# Ligne vidée + Entrée = annulation.
+# Lit une ligne éditable en place (readline) et l'écrit sur stdout.
+#
+# À appeler EN SUBSTITUTION DE COMMANDE, et pas autrement : bash quitte le
+# script lorsqu'un signal frappe le builtin `read` du shell principal, même
+# trappé — le trap s'exécute puis le shell part. Dans un sous-shell de
+# substitution, les traps sont réinitialisés : c'est le sous-shell qui meurt
+# (retour 130) et le shell parent, lui, poursuit et voit l'interruption.
+#
+# readline écrit invite et écho sur stdout, que la substitution capturerait
+# avec la réponse : ils sont renvoyés vers le terminal. Hors terminal, readline
+# est de toute façon inactif et il n'y a rien à afficher.
+_read_line_edited() {
+    local prefill="$1" prompt="$2" answer="" echo_to=/dev/null
+
+    if [[ -t 2 && -w /dev/tty ]]; then
+        echo_to=/dev/tty
+    fi
+
+    IFS= read -r -e -i "$prefill" -p "$prompt" answer >"$echo_to" || return $?
+    printf '%s' "$answer"
+}
+
+# Saisie éditée en place (readline). Entrée valide le texte affiché à l'écran :
+# le placeholder ne part jamais sans ce passage explicite.
+#
+# Deux régimes, selon le rôle passé en argument (indice dans les tableaux de
+# rôles ; sans argument, régime standard) :
+#   - standard : placeholder pré-rempli et modifiable, ligne vide = annulation ;
+#   - obligatoire (Owner, User Access Administrator) : rien de pré-rempli, une
+#     ligne vide est refusée et la question est reposée. Ctrl+C annule.
+#
 # Écrit dans $JUSTIFICATION plutôt que sur stdout : avec `read -e`, readline
 # écrit l'écho de la ligne, qu'une substitution de commande capturerait.
 prompt_justification() {
-    local answer=""
+    local index="${1-}" answer="" prefill="$DEFAULT_JUSTIFICATION" prompt mandatory=0 rc=0
 
     JUSTIFICATION=""
+
+    if [[ -n "$index" ]] && justification_is_mandatory "$index"; then
+        mandatory=1
+        prefill=""
+    fi
+
     printf '\n' >&2
-    if ! IFS= read -r -e -i "$DEFAULT_JUSTIFICATION" \
-            -p "Justification (Entrée valide, ligne vide annule) : " answer; then
-        printf '\n' >&2
-        return "$MENU_CANCELLED"
+    if (( mandatory )); then
+        info "Rôle sensible (${ROLE_NAMES[$index]:-${ROLE_LABELS[$index]}}) :"
+        info "justification obligatoire, aucun texte n'est pré-rempli."
+        prompt="Justification obligatoire (Ctrl+C annule) : "
+    else
+        prompt="Justification (Entrée valide, ligne vide annule) : "
     fi
 
-    answer="${answer#"${answer%%[![:space:]]*}"}"
-    answer="${answer%"${answer##*[![:space:]]}"}"
-    if [[ -z "$answer" ]]; then
-        return "$MENU_CANCELLED"
-    fi
+    while true; do
+        answer=""
+        rc=0
+        answer="$(_read_line_edited "$prefill" "$prompt")" || rc=$?
+        if (( rc != 0 )); then
+            # Ctrl+C : le trap a rendu la main au terminal, on remonte un code
+            # distinct pour que l'appelant reparte sur la liste. Sinon (EOF),
+            # c'est une annulation ordinaire.
+            if take_interrupt || (( rc > 128 )); then
+                return "$ACTIVATION_INTERRUPTED"
+            fi
+            printf '\n' >&2
+            return "$MENU_CANCELLED"
+        fi
 
-    JUSTIFICATION="$answer"
+        answer="${answer#"${answer%%[![:space:]]*}"}"
+        answer="${answer%"${answer##*[![:space:]]}"}"
+
+        if [[ -n "$answer" ]]; then
+            JUSTIFICATION="$answer"
+            return 0
+        fi
+
+        if (( mandatory == 0 )); then
+            return "$MENU_CANCELLED"
+        fi
+
+        err "Justification obligatoire pour ce rôle : saisissez un motif (Ctrl+C pour annuler)."
+    done
 }
 
 new_request_guid() {
@@ -771,65 +996,31 @@ submit_azure_activation() {
     return 1
 }
 
-# Graph attend `afterDuration` en camelCase là où ARM attend `AfterDuration`.
-_entra_activation_body() {
-    local index="$1"
 
-    jq -n \
-        --arg principalId "$AZ_PRINCIPAL_ID" \
-        --arg roleDefinitionId "${ROLE_DEFINITION_IDS[$index]}" \
-        --arg directoryScopeId "${ROLE_SCOPES[$index]}" \
-        --arg justification "$JUSTIFICATION" \
-        --arg start "$(iso_utc_now)" \
-        --arg duration "PT${DEFAULT_DURATION_HOURS}H" \
-        '{
-            action: "selfActivate",
-            principalId: $principalId,
-            roleDefinitionId: $roleDefinitionId,
-            directoryScopeId: $directoryScopeId,
-            justification: $justification,
-            scheduleInfo: {
-                startDateTime: $start,
-                expiration: { type: "afterDuration", duration: $duration }
-            }
-        }'
-}
-
-submit_entra_activation() {
-    local index="$1" response id
-
-    if ! response="$(az_rest_send POST "$GRAPH_REQUESTS_URL" "$(_entra_activation_body "$index")")"; then
-        err "Échec de la soumission de l'activation Entra."
-        explain_az_error
-        return 1
-    fi
-
-    id="$(jq -r '.id // empty' <<<"$response")"
-    if [[ -z "$id" ]]; then
-        err "Réponse Graph sans identifiant de demande — impossible de suivre le statut."
-        return 1
-    fi
-
-    POLL_URL="${GRAPH_REQUESTS_URL}/${id}"
-}
-
-# Les deux API partagent le vocabulaire de statuts (Provisioned, Granted,
-# PendingApproval, Failed…) ; seule l'orthographe de Cancelled/Canceled et
-# l'emplacement du champ diffèrent.
+# Statut de la demande ARM. Le vocabulaire est celui de PIM (Provisioned,
+# Granted, PendingApproval, Failed…), l'orthographe de Cancelled/Canceled
+# variant selon les endpoints — les deux sont traitées à l'appel.
 _request_status() {
-    if [[ "$SCOPE" == "azure" ]]; then
-        jq -r '.properties.status // empty'
-    else
-        jq -r '.status // empty'
-    fi
+    jq -r '.properties.status // empty'
 }
 
-# 0 = provisionné, 1 = échec API, 2 = toujours en attente au timeout.
+# 0 = provisionné, 1 = échec API, 2 = toujours en attente au timeout,
+# $ACTIVATION_INTERRUPTED = Ctrl+C pendant l'attente.
+#
+# Ni l'appel az (sous-shell de substitution) ni `sleep` ne rendent la main
+# d'eux-mêmes sur signal : le trap lève le drapeau, la boucle le consomme au
+# tour suivant et sort — la demande, elle, reste soumise côté Azure.
 poll_activation() {
     local elapsed=0 body status last=""
 
     printf 'Attente du provisionnement ' >&2
     while (( elapsed < POLL_TIMEOUT_SECONDS )); do
+        if take_interrupt; then
+            info "Attente interrompue — la demande reste soumise côté Azure."
+            info "Son état est consultable dans le portail PIM."
+            return "$ACTIVATION_INTERRUPTED"
+        fi
+
         if body="$(az_rest_get "$POLL_URL")"; then
             status="$(_request_status <<<"$body")"
             if [[ -n "$status" ]]; then
@@ -849,8 +1040,10 @@ poll_activation() {
                     ;;
             esac
         fi
+        # Échec d'appel isolé (réseau qui tombe en cours de polling) : on ne
+        # sort pas, la demande peut encore aboutir — le prochain tour réessaie.
         printf '.' >&2
-        sleep "$POLL_INTERVAL_SECONDS"
+        sleep "$POLL_INTERVAL_SECONDS" || true
         elapsed=$(( elapsed + POLL_INTERVAL_SECONDS ))
     done
 
@@ -862,31 +1055,59 @@ poll_activation() {
 }
 
 # Enchaîne récapitulatif → justification → soumission → polling.
-# Un timeout de polling n'est pas une erreur du script : il remonte 0.
+# Ne remonte JAMAIS de code destiné à faire quitter le script : la boucle
+# principale reprend la main dans tous les cas. Un timeout de polling et une
+# interruption ne sont pas des erreurs (retour 0) ; un échec d'API remonte 1
+# pour la trace, mais ramène lui aussi à la liste.
 activate_role() {
     local index="$1" rc=0
 
     show_selection "$index"
 
-    if ! prompt_justification; then
-        info "Activation annulée."
-        return 0
-    fi
+    prompt_justification "$index" || rc=$?
+    case $rc in
+        0) ;;
+        "$ACTIVATION_INTERRUPTED")
+            info "Activation abandonnée avant soumission."
+            return 0
+            ;;
+        *)
+            info "Activation annulée."
+            return 0
+            ;;
+    esac
 
-    resolve_principal_id || return 1
+    rc=0
+    resolve_principal_id || rc=$?
+    if (( rc != 0 )); then
+        take_interrupt || true
+        return 1
+    fi
 
     info ""
     info "Soumission de la demande (${DEFAULT_DURATION_HOURS}h)…"
     case "$SCOPE" in
-        azure) submit_azure_activation "$index" || return 1 ;;
-        entra) submit_entra_activation "$index" || return 1 ;;
-        *) err "Scope inconnu : $SCOPE"; return 1 ;;
+        azure)
+            rc=0
+            submit_azure_activation "$index" || rc=$?
+            ;;
+        *)
+            err "Scope inconnu : $SCOPE"
+            return 1
+            ;;
     esac
-
-    poll_activation || rc=$?
-    if (( rc == 2 )); then
-        rc=0
+    if (( rc != 0 )); then
+        # Une soumission interrompue au clavier a pu laisser le drapeau levé :
+        # on le consomme ici pour que la liste ne reparte pas sur un faux signal.
+        take_interrupt || true
+        return 1
     fi
+
+    rc=0
+    poll_activation || rc=$?
+    case $rc in
+        2|"$ACTIVATION_INTERRUPTED") rc=0 ;;
+    esac
     return "$rc"
 }
 
@@ -900,6 +1121,7 @@ main() {
     parse_args "$@" || return $?
 
     require_dependencies || return 1
+    install_signal_traps
     init_az_rest_error_file
     check_azure_session || return 1
 

--- a/pimMe/pim-activate.sh
+++ b/pimMe/pim-activate.sh
@@ -3,8 +3,9 @@
 # pim-activate.sh — Activation interactive de rôles PIM Azure / Entra ID.
 #
 # Alternative rapide au portail pour activer un rôle éligible : liste les rôles
-# activables de l'utilisateur connecté, en sélectionne un au clavier, et soumet
-# la demande d'activation.
+# activables de l'utilisateur connecté, en sélectionne un au clavier, demande
+# une justification, soumet la demande d'activation et suit son statut jusqu'au
+# provisionnement.
 #
 # Usage :
 #   ./pim-activate.sh [-s|--scope azure|entra] [-h|--help]
@@ -17,7 +18,9 @@
 #   - bash 4+ (tableaux, read -rsn1) — pas de compatibilité sh POSIX visée
 #   - az   : Azure CLI, avec une session active (`az login` au préalable ;
 #            le script ne déclenche jamais de login automatique)
-#   - jq   : parsing des réponses JSON
+#   - jq   : parsing des réponses JSON et construction des corps de requête
+#   - uuidgen (facultatif) : identifiant de la demande d'activation ARM ;
+#            repli automatique sur /proc/sys/kernel/random/uuid
 #
 # Codes de sortie :
 #   0   succès
@@ -32,12 +35,13 @@ set -euo pipefail
 
 SCRIPT_NAME="$(basename "$0")"
 
-# Durée d'activation par défaut (heures), utilisée par le flux d'activation
-# (goal 3) lorsque la politique PIM n'expose pas de maximum exploitable.
+# Durée d'activation demandée (heures). L'API d'éligibilité n'expose pas le
+# maximum autorisé par la politique PIM : la valeur est envoyée telle quelle et
+# un refus de la politique est diagnostiqué par explain_az_error.
 # Voir plan.md — hypothèse à ajuster selon le tenant.
 DEFAULT_DURATION_HOURS=8
 
-# Périmètre courant : azure | entra. Bascule à chaud prévue au goal 2.
+# Périmètre courant : azure | entra. Bascule à chaud par les touches a/e.
 SCOPE="azure"
 
 MENU_HINT="Flèches haut/bas + Entrée, numéro + Entrée, q pour annuler : "
@@ -403,7 +407,7 @@ list_azure_roles() {
 
     if ! body="$(az_rest_get "$ARM_ELIGIBLE_URL")"; then
         err "Échec de la récupération des rôles Azure eligible."
-        az_rest_last_error >&2
+        explain_az_error
         return 1
     fi
 
@@ -431,14 +435,7 @@ list_entra_roles() {
 
     if ! body="$(az_rest_get "$GRAPH_ELIGIBLE_URL")"; then
         err "Échec de la récupération des rôles Entra eligible."
-        # Cas fréquent et non corrigeable côté script : l'app Azure CLI n'a pas
-        # reçu le consentement Graph nécessaire dans ce tenant.
-        if az_rest_last_error | grep -q PermissionScopeNotGranted; then
-            err "L'application Azure CLI n'a pas les permissions Graph requises sur ce tenant."
-            err "Un administrateur doit consentir RoleManagement.Read.Directory (ou"
-            err "RoleEligibilitySchedule.Read.Directory) pour l'app 04b07795-8ddb-461a-bbee-02f9e1bf7b46."
-        fi
-        az_rest_last_error >&2
+        explain_az_error
         return 1
     fi
 
@@ -485,7 +482,7 @@ other_scope() {
     [[ "$1" == "azure" ]] && printf 'entra' || printf 'azure'
 }
 
-# Affiche le rôle choisi et ce que goal 3 consommera.
+# Récapitulatif du rôle choisi, affiché juste avant le prompt de justification.
 show_selection() {
     local index="$1"
 
@@ -494,7 +491,6 @@ show_selection() {
     printf '  roleDefinitionId     : %s\n' "${ROLE_DEFINITION_IDS[$index]}" >&2
     printf '  scope                : %s\n' "${ROLE_SCOPES[$index]}" >&2
     printf '  schedule eligible    : %s\n' "${ROLE_SCHEDULE_IDS[$index]}" >&2
-    printf '\nL'"'"'activation est hors périmètre du goal 2 (voir goal 3).\n' >&2
 }
 
 # Boucle de listing : affiche le scope courant, bascule sur a/e, sort sur q ou
@@ -537,8 +533,11 @@ browse_roles() {
 
         case $rc in
             0)
-                show_selection "$selection"
-                return 0
+                # `cmd; return $?` ne suffit pas sous set -e : un échec de
+                # activate_role sortirait du script avant le return.
+                rc=0
+                activate_role "$selection" || rc=$?
+                return "$rc"
                 ;;
             "$MENU_HOTKEY_PRESSED")
                 case "$selection" in
@@ -564,6 +563,331 @@ prompt_scope_switch() {
 
     read -r -p "Basculer vers le scope ${target} ? [o/N] " answer || return 1
     [[ "$answer" =~ ^[oOyY]$ ]]
+}
+
+# ---------------------------------------------------------------------------
+# Flux d'activation
+#
+# principalId : sur ce tenant les éligibilités sont portées par des GROUPES
+# (cf. section listing) — `properties.principalId` d'une instance vaut donc
+# l'objectId du GROUPE, jamais celui de l'utilisateur, et ne peut pas servir de
+# principalId à un SelfActivate. L'objectId de l'utilisateur est lu dans la
+# claim `oid` du jeton ARM plutôt que via `az ad signed-in-user show` : cela
+# n'ajoute aucune dépendance à Graph, dont ce tenant refuse déjà certaines
+# permissions à l'app Azure CLI (cf. explain_az_error).
+#
+# Le corps JSON part en argument `--body` et non via `@fichier` : az est ici le
+# binaire Windows sous WSL et ne saurait pas lire un chemin WSL. Vérifié :
+# l'interop WSL préserve guillemets et accents dans argv.
+# ---------------------------------------------------------------------------
+
+# Placeholder « business » proposé à l'écran, éditable avant validation.
+DEFAULT_JUSTIFICATION="Intervention support — troubleshooting"
+
+# Polling du statut de la demande. Pas de workflow d'approbation en v1
+# (cf. plan.md) : on affiche l'état et on sort au bout du timeout.
+POLL_INTERVAL_SECONDS=4
+POLL_TIMEOUT_SECONDS=60
+
+GRAPH_REQUESTS_URL="https://graph.microsoft.com/v1.0/roleManagement/directory/roleAssignmentScheduleRequests"
+
+AZ_PRINCIPAL_ID=""
+JUSTIFICATION=""
+POLL_URL=""
+
+# Traduit les erreurs az récurrentes en message actionnable, puis affiche le
+# détail brut. Partagé par le listing et l'activation.
+explain_az_error() {
+    local raw
+    raw="$(az_rest_last_error)"
+
+    case "$raw" in
+        *PermissionScopeNotGranted*)
+            err "L'application Azure CLI n'a pas les permissions Graph requises sur ce tenant."
+            err "Un administrateur doit consentir RoleManagement.Read.Directory (ou"
+            err "RoleEligibilitySchedule.Read.Directory) pour l'app 04b07795-8ddb-461a-bbee-02f9e1bf7b46."
+            ;;
+        *AADSTS70043*|*token_expired*|*invalid_grant*)
+            err "Session Azure CLI expirée (sign-in frequency de l'accès conditionnel)."
+            err "Relancez 'az login --tenant ${AZ_TENANT_ID:-<tenant>}' puis réessayez."
+            ;;
+        *AADSTS50076*|*AADSTS50079*|*MFA*|*mfa*|*claims*)
+            err "Ce rôle exige une authentification forte (MFA) récente."
+            err "Relancez 'az login --scope https://graph.microsoft.com//.default' puis réessayez."
+            ;;
+        *RoleAssignmentRequestPolicyValidationFailed*|*MaximumDuration*|*maximum*duration*)
+            err "Durée demandée refusée par la politique PIM du rôle."
+            err "Baissez DEFAULT_DURATION_HOURS (actuellement ${DEFAULT_DURATION_HOURS}h) en tête de script."
+            ;;
+    esac
+
+    if [[ -n "$raw" ]]; then
+        printf '%s\n' "$raw" >&2
+    fi
+    return 0
+}
+
+# Extrait la claim `oid` du payload d'un JWT (base64url, padding tronqué).
+_jwt_oid() {
+    local payload="$1" pad
+
+    payload="${payload//-/+}"
+    payload="${payload//_//}"
+    pad=$(( (4 - ${#payload} % 4) % 4 ))
+    while (( pad-- > 0 )); do
+        payload+="="
+    done
+
+    printf '%s' "$payload" | base64 -d 2>/dev/null | jq -r '.oid // empty' 2>/dev/null
+}
+
+# Résout (une seule fois) l'objectId de l'utilisateur connecté.
+resolve_principal_id() {
+    local token
+
+    if [[ -n "$AZ_PRINCIPAL_ID" ]]; then
+        return 0
+    fi
+
+    : > "$AZ_REST_ERROR_FILE"
+    if token="$(az account get-access-token --resource https://management.azure.com/ \
+                    --query accessToken -o tsv 2>"$AZ_REST_ERROR_FILE" </dev/null)"; then
+        AZ_PRINCIPAL_ID="$(_jwt_oid "$(cut -d. -f2 <<<"$token")")"
+    fi
+
+    # Repli si la claim manque : format de jeton inattendu, identité applicative.
+    if [[ -z "$AZ_PRINCIPAL_ID" ]]; then
+        AZ_PRINCIPAL_ID="$(az ad signed-in-user show --query id -o tsv \
+                               2>"$AZ_REST_ERROR_FILE" </dev/null || true)"
+    fi
+
+    if [[ -z "$AZ_PRINCIPAL_ID" ]]; then
+        err "Impossible de déterminer l'objectId de l'utilisateur connecté."
+        explain_az_error
+        return 1
+    fi
+}
+
+# Saisie pré-remplie et éditable en place (readline). Entrée valide le texte
+# affiché à l'écran : le placeholder ne part jamais sans ce passage explicite.
+# Ligne vidée + Entrée = annulation.
+# Écrit dans $JUSTIFICATION plutôt que sur stdout : avec `read -e`, readline
+# écrit l'écho de la ligne, qu'une substitution de commande capturerait.
+prompt_justification() {
+    local answer=""
+
+    JUSTIFICATION=""
+    printf '\n' >&2
+    if ! IFS= read -r -e -i "$DEFAULT_JUSTIFICATION" \
+            -p "Justification (Entrée valide, ligne vide annule) : " answer; then
+        printf '\n' >&2
+        return "$MENU_CANCELLED"
+    fi
+
+    answer="${answer#"${answer%%[![:space:]]*}"}"
+    answer="${answer%"${answer##*[![:space:]]}"}"
+    if [[ -z "$answer" ]]; then
+        return "$MENU_CANCELLED"
+    fi
+
+    JUSTIFICATION="$answer"
+}
+
+new_request_guid() {
+    local guid
+    if command -v uuidgen >/dev/null 2>&1; then
+        guid="$(uuidgen)"
+    else
+        guid="$(< /proc/sys/kernel/random/uuid)"
+    fi
+    printf '%s' "${guid,,}"
+}
+
+iso_utc_now() {
+    date -u +%Y-%m-%dT%H:%M:%SZ
+}
+
+# Appel avec corps JSON, même gestion d'erreur que az_rest_get.
+az_rest_send() {
+    local method="$1" url="$2" body="$3" out rc=0
+
+    : > "$AZ_REST_ERROR_FILE"
+    out="$(az rest --method "$method" --url "$url" \
+              --headers "Content-Type=application/json" \
+              --body "$body" -o json 2>"$AZ_REST_ERROR_FILE" </dev/null)" || rc=$?
+
+    (( rc == 0 )) || return "$rc"
+    printf '%s' "$out"
+}
+
+# $2 vide = corps sans linkedRoleEligibilityScheduleId.
+_azure_activation_body() {
+    local index="$1" linked="$2"
+
+    jq -n \
+        --arg principalId "$AZ_PRINCIPAL_ID" \
+        --arg roleDefinitionId "${ROLE_DEFINITION_IDS[$index]}" \
+        --arg justification "$JUSTIFICATION" \
+        --arg start "$(iso_utc_now)" \
+        --arg duration "PT${DEFAULT_DURATION_HOURS}H" \
+        --arg linked "$linked" \
+        '{properties: ({
+            principalId: $principalId,
+            roleDefinitionId: $roleDefinitionId,
+            requestType: "SelfActivate",
+            justification: $justification,
+            scheduleInfo: {
+                startDateTime: $start,
+                expiration: { type: "AfterDuration", duration: $duration }
+            }
+          } + (if $linked == "" then {} else { linkedRoleEligibilityScheduleId: $linked } end))}'
+}
+
+# Soumission ARM. `linkedRoleEligibilityScheduleId` est optionnel côté API :
+# on tente d'abord sans, et on ne rejoue avec que si l'API le réclame — la doc
+# ne le rend obligatoire dans aucun cas, seul le test tranche (cf. goal 3).
+submit_azure_activation() {
+    local index="$1" guid url
+
+    guid="$(new_request_guid)"
+    url="https://management.azure.com${ROLE_SCOPES[$index]}/providers/Microsoft.Authorization/roleAssignmentScheduleRequests/${guid}?api-version=${ARM_API_VERSION}"
+
+    if az_rest_send PUT "$url" "$(_azure_activation_body "$index" "")" >/dev/null; then
+        POLL_URL="$url"
+        return 0
+    fi
+
+    if az_rest_last_error | grep -qi 'linkedRoleEligibilityScheduleId'; then
+        info "L'API réclame la schedule eligible liée — nouvelle tentative."
+        if az_rest_send PUT "$url" \
+               "$(_azure_activation_body "$index" "${ROLE_SCHEDULE_IDS[$index]}")" >/dev/null; then
+            POLL_URL="$url"
+            return 0
+        fi
+    fi
+
+    err "Échec de la soumission de l'activation Azure."
+    explain_az_error
+    return 1
+}
+
+# Graph attend `afterDuration` en camelCase là où ARM attend `AfterDuration`.
+_entra_activation_body() {
+    local index="$1"
+
+    jq -n \
+        --arg principalId "$AZ_PRINCIPAL_ID" \
+        --arg roleDefinitionId "${ROLE_DEFINITION_IDS[$index]}" \
+        --arg directoryScopeId "${ROLE_SCOPES[$index]}" \
+        --arg justification "$JUSTIFICATION" \
+        --arg start "$(iso_utc_now)" \
+        --arg duration "PT${DEFAULT_DURATION_HOURS}H" \
+        '{
+            action: "selfActivate",
+            principalId: $principalId,
+            roleDefinitionId: $roleDefinitionId,
+            directoryScopeId: $directoryScopeId,
+            justification: $justification,
+            scheduleInfo: {
+                startDateTime: $start,
+                expiration: { type: "afterDuration", duration: $duration }
+            }
+        }'
+}
+
+submit_entra_activation() {
+    local index="$1" response id
+
+    if ! response="$(az_rest_send POST "$GRAPH_REQUESTS_URL" "$(_entra_activation_body "$index")")"; then
+        err "Échec de la soumission de l'activation Entra."
+        explain_az_error
+        return 1
+    fi
+
+    id="$(jq -r '.id // empty' <<<"$response")"
+    if [[ -z "$id" ]]; then
+        err "Réponse Graph sans identifiant de demande — impossible de suivre le statut."
+        return 1
+    fi
+
+    POLL_URL="${GRAPH_REQUESTS_URL}/${id}"
+}
+
+# Les deux API partagent le vocabulaire de statuts (Provisioned, Granted,
+# PendingApproval, Failed…) ; seule l'orthographe de Cancelled/Canceled et
+# l'emplacement du champ diffèrent.
+_request_status() {
+    if [[ "$SCOPE" == "azure" ]]; then
+        jq -r '.properties.status // empty'
+    else
+        jq -r '.status // empty'
+    fi
+}
+
+# 0 = provisionné, 1 = échec API, 2 = toujours en attente au timeout.
+poll_activation() {
+    local elapsed=0 body status last=""
+
+    printf 'Attente du provisionnement ' >&2
+    while (( elapsed < POLL_TIMEOUT_SECONDS )); do
+        if body="$(az_rest_get "$POLL_URL")"; then
+            status="$(_request_status <<<"$body")"
+            if [[ -n "$status" ]]; then
+                last="$status"
+            fi
+            case "$status" in
+                Provisioned|Granted)
+                    printf '\n' >&2
+                    info "Rôle activé (${status}) pour ${DEFAULT_DURATION_HOURS}h."
+                    return 0
+                    ;;
+                Failed|Denied|Revoked|Cancelled|Canceled)
+                    printf '\n' >&2
+                    err "Activation en échec (statut ${status})."
+                    jq -c '.' <<<"$body" >&2
+                    return 1
+                    ;;
+            esac
+        fi
+        printf '.' >&2
+        sleep "$POLL_INTERVAL_SECONDS"
+        elapsed=$(( elapsed + POLL_INTERVAL_SECONDS ))
+    done
+
+    printf '\n' >&2
+    info "Toujours en attente après ${POLL_TIMEOUT_SECONDS}s (dernier statut : ${last:-inconnu})."
+    info "Une demande soumise à approbation continue d'être traitée côté portail ;"
+    info "le workflow d'approbation n'est pas géré par ce script (cf. plan.md)."
+    return 2
+}
+
+# Enchaîne récapitulatif → justification → soumission → polling.
+# Un timeout de polling n'est pas une erreur du script : il remonte 0.
+activate_role() {
+    local index="$1" rc=0
+
+    show_selection "$index"
+
+    if ! prompt_justification; then
+        info "Activation annulée."
+        return 0
+    fi
+
+    resolve_principal_id || return 1
+
+    info ""
+    info "Soumission de la demande (${DEFAULT_DURATION_HOURS}h)…"
+    case "$SCOPE" in
+        azure) submit_azure_activation "$index" || return 1 ;;
+        entra) submit_entra_activation "$index" || return 1 ;;
+        *) err "Scope inconnu : $SCOPE"; return 1 ;;
+    esac
+
+    poll_activation || rc=$?
+    if (( rc == 2 )); then
+        rc=0
+    fi
+    return "$rc"
 }
 
 # ---------------------------------------------------------------------------

--- a/pimMe/pim-activate.sh
+++ b/pimMe/pim-activate.sh
@@ -48,6 +48,14 @@ MENU_HINT="Flèches haut/bas + Entrée, numéro + Entrée, q pour annuler : "
 # Le trap Ctrl+C du goal 4 doit rester distinguable d'une annulation de menu.
 MENU_CANCELLED=64
 
+# Touches d'action passées au menu par l'appelant (goal 2 : a/e pour basculer
+# de scope). Vide par défaut : le contrat du goal 1 est inchangé.
+MENU_HOTKEYS=()
+# Retour de select_from_menu quand une hotkey est pressée : la touche est
+# écrite sur stdout. Passer par stdout et non par une variable globale est
+# imposé par l'appel en substitution de commande, qui isole le sous-shell.
+MENU_HOTKEY_PRESSED=65
+
 usage() {
     cat <<EOF
 Usage: $SCRIPT_NAME [-s|--scope azure|entra] [-h|--help]
@@ -108,6 +116,15 @@ require_dependencies() {
 # Bash pur — aucune dépendance externe (pas de fzf).
 # ---------------------------------------------------------------------------
 
+_menu_is_hotkey() {
+    local candidate="$1" hotkey
+    (( ${#MENU_HOTKEYS[@]} > 0 )) || return 1
+    for hotkey in "${MENU_HOTKEYS[@]}"; do
+        [[ "$candidate" == "$hotkey" ]] && return 0
+    done
+    return 1
+}
+
 _menu_render() {
     local count=${#_menu_options[@]}
     local i line
@@ -121,7 +138,7 @@ _menu_render() {
 
     printf '%s\n' "$_menu_prompt" >&2
     for i in "${!_menu_options[@]}"; do
-        line="$(printf '%d) %s' "$((i + 1))" "${_menu_options[$i]}")"
+        line="$(printf '%*d) %s' "${#count}" "$((i + 1))" "${_menu_options[$i]}")"
         if (( i == _menu_selected )); then
             if [[ -t 2 ]]; then
                 printf '\033[7m> %s\033[0m\n' "$line" >&2
@@ -132,7 +149,11 @@ _menu_render() {
             printf '  %s\n' "$line" >&2
         fi
     done
-    printf '%s%s' "$MENU_HINT" "$_menu_typed" >&2
+    printf '%s' "$MENU_HINT" >&2
+    if (( ${#MENU_HOTKEYS[@]} > 0 )); then
+        printf '(%s) ' "$(IFS='/'; printf '%s' "${MENU_HOTKEYS[*]}")" >&2
+    fi
+    printf '%s' "$_menu_typed" >&2
     _menu_drawn=1
 }
 
@@ -193,6 +214,13 @@ select_from_menu() {
             q|Q)
                 printf '\n' >&2
                 return "$MENU_CANCELLED"
+                ;;
+            *)
+                if _menu_is_hotkey "$key"; then
+                    printf '\n' >&2
+                    printf '%s\n' "$key"
+                    return "$MENU_HOTKEY_PRESSED"
+                fi
                 ;;
         esac
     done
@@ -261,7 +289,9 @@ check_azure_session() {
     local az_err
 
     az_err="$(mktemp)"
-    if ! AZ_ACCOUNT_JSON="$(az account show -o json 2>"$az_err")"; then
+    # </dev/null : az est ici le binaire Windows sous WSL et draine stdin, ce
+    # qui volerait les frappes destinées au menu quand l'entrée est un pipe.
+    if ! AZ_ACCOUNT_JSON="$(az account show -o json 2>"$az_err" </dev/null)"; then
         err "Aucune session Azure CLI active. Lancez 'az login' puis réessayez."
         if [[ -s "$az_err" ]]; then
             printf "Détail az : %s\n" "$(head -n 1 "$az_err")" >&2
@@ -283,6 +313,260 @@ check_azure_session() {
 }
 
 # ---------------------------------------------------------------------------
+# Récupération des rôles eligible
+#
+# Chemin de listing Azure retenu : scope racine "/" + $filter=asTarget().
+#
+# Le filtre `principalId eq '{objectId}'` prévu dans plan.md a été testé et
+# renvoie systématiquement une liste vide sur ce tenant : les éligibilités y
+# sont portées par des GROUPES (memberType=Inherited, principalType=Group), pas
+# par des affectations directes à l'utilisateur. Un filtre sur l'objectId de
+# l'utilisateur ne peut donc rien matcher. `asTarget()` résout au contraire
+# l'appartenance transitive et retourne bien « ce à quoi j'ai droit ».
+#
+# Le fallback « boucle sur az account list » n'est pas nécessaire : appelé sur
+# le scope racine, asTarget() cascade sur toute la hiérarchie (management
+# groups + souscriptions) en UN appel. Vérifié en test réel : l'union des
+# résultats par souscription est un sous-ensemble strict du résultat racine
+# (les éligibilités portées au niveau management group n'apparaissent pas dans
+# la boucle par souscription).
+#
+# Les parenthèses de asTarget() DOIVENT être encodées en %28%29 : ARM répond
+# 400 "Bad Request - Invalid URL" sur les parenthèses brutes. Graph, lui, les
+# accepte telles quelles.
+# ---------------------------------------------------------------------------
+
+ARM_API_VERSION="2020-10-01"
+ARM_ELIGIBLE_URL="https://management.azure.com/providers/Microsoft.Authorization/roleEligibilityScheduleInstances?api-version=${ARM_API_VERSION}&\$filter=asTarget%28%29"
+GRAPH_ELIGIBLE_URL="https://graph.microsoft.com/v1.0/roleManagement/directory/roleEligibilityScheduleInstances/filterByCurrentUser(on='principal')?%24expand=roleDefinition"
+
+# Dernière erreur brute renvoyée par az rest, pour un diagnostic exploitable.
+# Stockée dans un FICHIER et non dans une variable : les appelants invoquent
+# az_rest_get en substitution de commande, dont le sous-shell ne peut pas
+# propager une affectation de variable au processus parent.
+AZ_REST_ERROR_FILE=""
+
+init_az_rest_error_file() {
+    AZ_REST_ERROR_FILE="$(mktemp)"
+    trap 'rm -f "$AZ_REST_ERROR_FILE"' EXIT
+}
+
+az_rest_last_error() {
+    [[ -n "$AZ_REST_ERROR_FILE" && -s "$AZ_REST_ERROR_FILE" ]] || return 0
+    cat "$AZ_REST_ERROR_FILE"
+}
+
+# Appel GET commun aux deux API. stdin fermé : az est ici le binaire Windows
+# sous WSL et draine stdin, ce qui volerait les frappes destinées au menu.
+az_rest_get() {
+    local url="$1" body rc=0
+
+    : > "$AZ_REST_ERROR_FILE"
+    # `|| rc=$?` et non `if ...; fi` puis `rc=$?` : après un `fi` dont aucune
+    # branche n'a été prise, $? vaut 0 et masque l'échec de la commande.
+    body="$(az rest --method get --url "$url" -o json 2>"$AZ_REST_ERROR_FILE" </dev/null)" || rc=$?
+
+    (( rc == 0 )) || return "$rc"
+    printf '%s' "$body"
+}
+
+# Tableaux parallèles décrivant les rôles du scope courant. Chaque entrée porte
+# tout ce dont goal 3 a besoin pour construire la requête d'activation sans
+# re-quêter l'API (cf. contrainte du goal 2).
+ROLE_LABELS=()
+ROLE_DEFINITION_IDS=()
+ROLE_SCOPES=()
+ROLE_SCHEDULE_IDS=()
+
+reset_roles() {
+    ROLE_LABELS=()
+    ROLE_DEFINITION_IDS=()
+    ROLE_SCOPES=()
+    ROLE_SCHEDULE_IDS=()
+}
+
+# Alimente les tableaux depuis un flux TSV « label \t defId \t scope \t schedId ».
+# Le TSV vient exclusivement de `jq -r ... | @tsv` : aucune regex sur du JSON.
+ingest_roles_tsv() {
+    local label def_id scope sched_id
+    while IFS=$'\t' read -r label def_id scope sched_id; do
+        [[ -n "$label" ]] || continue
+        ROLE_LABELS+=("$label")
+        ROLE_DEFINITION_IDS+=("$def_id")
+        ROLE_SCOPES+=("$scope")
+        ROLE_SCHEDULE_IDS+=("$sched_id")
+    done
+}
+
+list_azure_roles() {
+    local body
+
+    if ! body="$(az_rest_get "$ARM_ELIGIBLE_URL")"; then
+        err "Échec de la récupération des rôles Azure eligible."
+        az_rest_last_error >&2
+        return 1
+    fi
+
+    # scope.displayName est plus lisible que l'ID ; on retombe sur l'ID brut
+    # si l'API ne renvoie pas expandedProperties.
+    ingest_roles_tsv < <(jq -r '
+        .value[]
+        | . as $i
+        | [
+            ( ($i.properties.expandedProperties.roleDefinition.displayName // $i.properties.roleDefinitionId)
+              + "  —  "
+              + ($i.properties.expandedProperties.scope.type // "scope")
+              + " "
+              + ($i.properties.expandedProperties.scope.displayName // $i.properties.scope) ),
+            $i.properties.roleDefinitionId,
+            $i.properties.scope,
+            $i.properties.roleEligibilityScheduleId
+          ]
+        | @tsv
+    ' <<<"$body" | sort)
+}
+
+list_entra_roles() {
+    local body
+
+    if ! body="$(az_rest_get "$GRAPH_ELIGIBLE_URL")"; then
+        err "Échec de la récupération des rôles Entra eligible."
+        # Cas fréquent et non corrigeable côté script : l'app Azure CLI n'a pas
+        # reçu le consentement Graph nécessaire dans ce tenant.
+        if az_rest_last_error | grep -q PermissionScopeNotGranted; then
+            err "L'application Azure CLI n'a pas les permissions Graph requises sur ce tenant."
+            err "Un administrateur doit consentir RoleManagement.Read.Directory (ou"
+            err "RoleEligibilitySchedule.Read.Directory) pour l'app 04b07795-8ddb-461a-bbee-02f9e1bf7b46."
+        fi
+        az_rest_last_error >&2
+        return 1
+    fi
+
+    # Pour Entra, directoryScopeId tient le rôle du scope ARM ; "/" = tenant.
+    ingest_roles_tsv < <(jq -r '
+        .value[]
+        | . as $i
+        | [
+            ( ($i.roleDefinition.displayName // $i.roleDefinitionId)
+              + "  —  annuaire "
+              + (if ($i.directoryScopeId // "/") == "/" then "tenant" else $i.directoryScopeId end) ),
+            $i.roleDefinitionId,
+            ($i.directoryScopeId // "/"),
+            $i.id
+          ]
+        | @tsv
+    ' <<<"$body" | sort)
+}
+
+# Charge les rôles du scope demandé. Retour 0 = chargé (éventuellement vide),
+# 1 = échec d'appel.
+load_roles() {
+    local scope="$1"
+
+    reset_roles
+    case "$scope" in
+        azure) list_azure_roles ;;
+        entra) list_entra_roles ;;
+        *) err "Scope inconnu : $scope"; return 1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Navigation
+#
+# Choix d'implémentation pour la bascule de scope : plutôt que de dupliquer une
+# boucle de lecture clavier au-dessus du menu, select_from_menu accepte des
+# touches d'action ($MENU_HOTKEYS) et rend la main avec $MENU_HOTKEY_PRESSED en
+# écrivant la touche sur stdout. Une seule boucle de lecture, un seul rendu, et
+# le contrat du goal 1 reste intact quand MENU_HOTKEYS est vide.
+# ---------------------------------------------------------------------------
+
+other_scope() {
+    [[ "$1" == "azure" ]] && printf 'entra' || printf 'azure'
+}
+
+# Affiche le rôle choisi et ce que goal 3 consommera.
+show_selection() {
+    local index="$1"
+
+    printf '\nRôle sélectionné :\n' >&2
+    printf '  libellé              : %s\n' "${ROLE_LABELS[$index]}" >&2
+    printf '  roleDefinitionId     : %s\n' "${ROLE_DEFINITION_IDS[$index]}" >&2
+    printf '  scope                : %s\n' "${ROLE_SCOPES[$index]}" >&2
+    printf '  schedule eligible    : %s\n' "${ROLE_SCHEDULE_IDS[$index]}" >&2
+    printf '\nL'"'"'activation est hors périmètre du goal 2 (voir goal 3).\n' >&2
+}
+
+# Boucle de listing : affiche le scope courant, bascule sur a/e, sort sur q ou
+# sélection. La boucle complète post-activation appartient au goal 4.
+browse_roles() {
+    local selection rc target
+
+    while true; do
+        info "Chargement des rôles eligible (scope ${SCOPE})…"
+        if ! load_roles "$SCOPE"; then
+            target="$(other_scope "$SCOPE")"
+            info ""
+            info "Impossible de lister le scope ${SCOPE}."
+            if ! prompt_scope_switch "$target"; then
+                return 1
+            fi
+            SCOPE="$target"
+            continue
+        fi
+
+        if (( ${#ROLE_LABELS[@]} == 0 )); then
+            target="$(other_scope "$SCOPE")"
+            info ""
+            info "Aucun rôle eligible sur ce scope (${SCOPE})."
+            if ! prompt_scope_switch "$target"; then
+                return 0
+            fi
+            SCOPE="$target"
+            continue
+        fi
+
+        MENU_HOTKEYS=("a" "e")
+        # `x="$(cmd)"` qui échoue sort du script sous set -e avant tout rc=$? :
+        # on capture le code dans la même commande composée.
+        rc=0
+        selection="$(select_from_menu \
+            "Rôles ${SCOPE} eligible (${#ROLE_LABELS[@]}) — a=azure e=entra q=quitter :" \
+            "${ROLE_LABELS[@]}")" || rc=$?
+        MENU_HOTKEYS=()
+
+        case $rc in
+            0)
+                show_selection "$selection"
+                return 0
+                ;;
+            "$MENU_HOTKEY_PRESSED")
+                case "$selection" in
+                    a) SCOPE="azure" ;;
+                    e) SCOPE="entra" ;;
+                esac
+                ;;
+            "$MENU_CANCELLED")
+                info "Annulé."
+                return 0
+                ;;
+            *)
+                err "Retour inattendu du menu : $rc"
+                return 1
+                ;;
+        esac
+    done
+}
+
+# Propose de basculer vers l'autre scope quand le courant est vide ou en échec.
+prompt_scope_switch() {
+    local target="$1" answer
+
+    read -r -p "Basculer vers le scope ${target} ? [o/N] " answer || return 1
+    [[ "$answer" =~ ^[oOyY]$ ]]
+}
+
+# ---------------------------------------------------------------------------
 # Entrée
 # ---------------------------------------------------------------------------
 
@@ -292,11 +576,12 @@ main() {
     parse_args "$@" || return $?
 
     require_dependencies || return 1
+    init_az_rest_error_file
     check_azure_session || return 1
 
     info "Connecté en tant que ${AZ_USER_NAME} (tenant ${AZ_TENANT_ID})."
-    info "Périmètre courant : ${SCOPE}."
-    info "Socle prêt — le listing des rôles éligibles arrive au goal 2."
+
+    browse_roles
 }
 
 # Garde de sourçage : permet de charger le script pour tester select_from_menu

--- a/pimMe/plan.md
+++ b/pimMe/plan.md
@@ -1,0 +1,40 @@
+---
+statut: à valider
+maj: 2026-08-27
+tags: [plan, script, pim, azure, entra]
+---
+# Plan — pim-activate.sh
+
+## Contexte
+
+Script bash interactif d'activation de rôles PIM (Azure resource roles + Entra ID directory roles), pensé comme alternative rapide au portail. Découpé en 4 goals séquentiels, chacun conçu pour être donné tel quel en prompt de démarrage d'une session Claude Code.
+
+## Décisions de design retenues
+
+- **Listing Azure** : filtre `principalId eq {objectId}` sur un scope racine (management group racine du tenant) plutôt qu'une boucle par souscription — un seul appel cascade sur toute la hiérarchie. **Hypothèse à valider** en test réel ; si résultat vide/incomplet, fallback = boucle sur `az account list`.
+- **Navigation menu** : composant bash pur (pas de dépendance externe type `fzf`), support flèches haut/bas + Entrée ET saisie directe du numéro + Entrée.
+- **Durée d'activation** : le script utilise la durée max exposée par l'API si disponible, sinon une constante `DEFAULT_DURATION_HOURS` (8h par défaut) en tête de script. **Hypothèse à ajuster** selon la politique PIM réelle du tenant.
+- **Approval workflow** (`PendingApproval`) : non géré en v1. Le script affiche l'état et sort du polling après un timeout (60s), retour au menu.
+- **MFA sur activation Entra** : risque connu (l'API peut exiger une claim MFA fraîche). Le script détecte l'erreur et affiche un message explicite plutôt que de planter.
+
+## Séquencement
+
+1. `goal-1-foundations.md` — squelette, dépendances (`az`, `jq`), check auth, parsing des arguments, composant de menu interactif réutilisable.
+2. `goal-2-list-roles.md` — récupération et affichage des rôles PIM eligible (Azure ARM + Entra Graph), switch de scope par lettre.
+3. `goal-3-activation-flow.md` — prompt de justification, soumission de la demande d'activation, polling du statut.
+4. `goal-4-main-loop.md` — boucle principale complète, gestion d'erreurs globale, documentation finale du script.
+
+L'ordre est important : chaque goal dépend du résultat du précédent. Valider (test manuel sur un tenant réel) avant de passer au suivant.
+
+## Hors scope (rappel, tous goals confondus)
+
+- Désactivation d'un rôle actif.
+- Gestion du workflow d'approbation.
+- Multi-tenant.
+
+## Sources techniques (MS Learn)
+
+- Activate my Azure resource roles in PIM — https://learn.microsoft.com/entra/id-governance/privileged-identity-management/pim-resource-roles-activate-your-roles
+- Create roleAssignmentScheduleRequests (Graph) — https://learn.microsoft.com/graph/api/rbacapplication-post-roleassignmentschedulerequests
+- unifiedRoleEligibilityScheduleInstance: filterByCurrentUser — https://learn.microsoft.com/graph/api/unifiedroleeligibilityscheduleinstance-filterbycurrentuser
+- az account get-access-token (résolution de token, fallback) — https://learn.microsoft.com/cli/azure/account

--- a/pimMe/tests/test_activation.sh
+++ b/pimMe/tests/test_activation.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+#
+# tests/test_activation.sh — Tests du flux d'activation (pim-activate.sh, goal 3).
+#
+# Couvre tout ce qui est déterminable hors ligne : construction des corps de
+# requête, décodage de la claim `oid`, lecture du statut de la demande, prompt
+# de justification, diagnostic des erreurs az. Aucun appel réseau — la
+# soumission réelle et le polling se valident sur un tenant (cf. goal 3).
+#
+# Usage :
+#   bash tests/test_activation.sh
+#
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${TEST_DIR}/../pim-activate.sh"
+
+# shellcheck source=../pim-activate.sh
+source "$TARGET"
+# pim-activate.sh pose `set -euo pipefail` en se sourçant : on relâche -e, le
+# harnais teste justement des retours non-zéro.
+set +e
+
+fails=0
+
+check() {
+    local label="$1" expected="$2" got="$3"
+    if [[ "$got" == "$expected" ]]; then
+        printf 'PASS  %-48s -> %s\n' "$label" "$got"
+    else
+        printf 'FAIL  %-48s -> attendu "%s", obtenu "%s"\n' "$label" "$expected" "$got"
+        fails=$((fails + 1))
+    fi
+}
+
+# Jeu de données : un rôle Azure (scope ARM) et un rôle Entra (scope annuaire).
+ROLE_LABELS=("Owner — subscription SandBox" "Global Reader — annuaire tenant")
+ROLE_DEFINITION_IDS=(
+    "/subscriptions/0000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+    "f2ef992c-3afb-46b9-b7cf-a126ee74c451"
+)
+ROLE_SCOPES=("/subscriptions/0000" "/")
+ROLE_SCHEDULE_IDS=(
+    "/subscriptions/0000/providers/Microsoft.Authorization/roleEligibilitySchedules/abcd"
+    "sched-entra-1"
+)
+
+AZ_PRINCIPAL_ID="11111111-2222-3333-4444-555555555555"
+# Volontairement piégeuse : guillemets, apostrophe, accents, backslash.
+JUSTIFICATION='Incident "P1" — l'"'"'accès prod\test'
+
+printf '=== Corps de requête Azure (ARM) ===\n'
+
+body="$(_azure_activation_body 0 "")"
+check "JSON valide"                       "ok"    "$(jq -e . >/dev/null 2>&1 <<<"$body" && echo ok || echo ko)"
+check "requestType"                       "SelfActivate" "$(jq -r '.properties.requestType' <<<"$body")"
+check "principalId = utilisateur"         "$AZ_PRINCIPAL_ID" "$(jq -r '.properties.principalId' <<<"$body")"
+check "roleDefinitionId"                  "${ROLE_DEFINITION_IDS[0]}" "$(jq -r '.properties.roleDefinitionId' <<<"$body")"
+check "justification échappée telle quelle" "$JUSTIFICATION" "$(jq -r '.properties.justification' <<<"$body")"
+check "expiration.type"                   "AfterDuration" "$(jq -r '.properties.scheduleInfo.expiration.type' <<<"$body")"
+check "duration = DEFAULT_DURATION_HOURS" "PT${DEFAULT_DURATION_HOURS}H" "$(jq -r '.properties.scheduleInfo.expiration.duration' <<<"$body")"
+check "startDateTime au format ISO UTC"   "ok" "$(jq -r '.properties.scheduleInfo.startDateTime' <<<"$body" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' && echo ok || echo ko)"
+check "linked absent par défaut"          "null" "$(jq -r '.properties.linkedRoleEligibilityScheduleId // "null"' <<<"$body")"
+
+body="$(_azure_activation_body 0 "${ROLE_SCHEDULE_IDS[0]}")"
+check "linked présent au 2e essai"        "${ROLE_SCHEDULE_IDS[0]}" "$(jq -r '.properties.linkedRoleEligibilityScheduleId' <<<"$body")"
+
+printf '\n=== Corps de requête Entra (Graph) ===\n'
+
+body="$(_entra_activation_body 1)"
+check "JSON valide"                       "ok" "$(jq -e . >/dev/null 2>&1 <<<"$body" && echo ok || echo ko)"
+check "action selfActivate"               "selfActivate" "$(jq -r '.action' <<<"$body")"
+check "directoryScopeId depuis ROLE_SCOPES" "/" "$(jq -r '.directoryScopeId' <<<"$body")"
+check "roleDefinitionId nu (pas de chemin ARM)" "${ROLE_DEFINITION_IDS[1]}" "$(jq -r '.roleDefinitionId' <<<"$body")"
+# Graph refuse la casse ARM : afterDuration, pas AfterDuration.
+check "expiration.type camelCase"         "afterDuration" "$(jq -r '.scheduleInfo.expiration.type' <<<"$body")"
+check "pas d'enveloppe properties"        "null" "$(jq -r '.properties // "null"' <<<"$body")"
+
+printf '\n=== Claim oid du jeton ARM ===\n'
+
+# Payload base64url sans padding, avec un `_` et un `-` dans le corps encodé.
+make_jwt_payload() {
+    printf '%s' "$1" | base64 -w0 | tr '+/' '-_' | tr -d '='
+}
+check "oid extrait"        "$AZ_PRINCIPAL_ID" "$(_jwt_oid "$(make_jwt_payload "{\"oid\":\"$AZ_PRINCIPAL_ID\",\"upn\":\"a@b.c\"}")")"
+check "padding à 2 restitué" "abc"            "$(_jwt_oid "$(make_jwt_payload '{"oid":"abc","x":"1"}')")"
+check "claim absente -> vide" ""              "$(_jwt_oid "$(make_jwt_payload '{"upn":"a@b.c"}')")"
+check "payload illisible -> vide" ""          "$(_jwt_oid 'pas-du-base64!!')"
+
+printf '\n=== Statut de la demande ===\n'
+
+SCOPE="azure"
+check "ARM : .properties.status"  "Provisioned" "$(_request_status <<<'{"properties":{"status":"Provisioned"}}')"
+check "ARM : statut absent"       ""            "$(_request_status <<<'{"properties":{}}')"
+SCOPE="entra"
+check "Graph : .status"           "Granted"     "$(_request_status <<<'{"status":"Granted","id":"x"}')"
+SCOPE="azure"
+
+printf '\n=== GUID de demande ===\n'
+
+guid="$(new_request_guid)"
+check "format uuid minuscule" "ok" "$(grep -Eq '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' <<<"$guid" && echo ok || echo ko)"
+check "deux appels diffèrent"  "ok" "$([[ "$guid" != "$(new_request_guid)" ]] && echo ok || echo ko)"
+
+printf '\n=== Prompt de justification ===\n'
+# Hors terminal, readline est désactivé : -i ne pré-remplit pas. C'est
+# précisément le contrat testé ici — seul le texte réellement validé compte.
+
+# Redirection par substitution de processus et NON par pipe : un pipe placerait
+# prompt_justification dans un sous-shell, où l'écriture de $JUSTIFICATION
+# serait perdue — exactement ce que le passage par variable globale évite.
+
+JUSTIFICATION="sentinelle"
+prompt_justification < <(printf '  Intervention support  \n') >/dev/null 2>&1
+check "texte saisi, espaces rognés" "Intervention support" "$JUSTIFICATION"
+
+JUSTIFICATION="sentinelle"
+prompt_justification < <(printf '\n') >/dev/null 2>&1; rc=$?
+check "ligne vide -> annulation"    "$MENU_CANCELLED" "$rc"
+check "ligne vide -> rien à soumettre" "" "$JUSTIFICATION"
+
+JUSTIFICATION="sentinelle"
+prompt_justification < /dev/null >/dev/null 2>&1; rc=$?
+check "EOF -> annulation"           "$MENU_CANCELLED" "$rc"
+check "EOF -> rien à soumettre"     "" "$JUSTIFICATION"
+
+printf '\n=== Diagnostic des erreurs az ===\n'
+
+AZ_REST_ERROR_FILE="$(mktemp)"
+trap 'rm -f "$AZ_REST_ERROR_FILE"' EXIT
+AZ_TENANT_ID="bb2cf736-0000-0000-0000-000000000000"
+
+diagnose() {
+    printf '%s\n' "$1" > "$AZ_REST_ERROR_FILE"
+    explain_az_error 2>&1
+}
+check "consentement Graph manquant" "ok" "$(diagnose 'ERROR: PermissionScopeNotGranted' | grep -q 'permissions Graph' && echo ok || echo ko)"
+check "session expirée (AADSTS70043)" "ok" "$(diagnose 'SubError: token_expired AADSTS70043: refresh token expired' | grep -q 'Session Azure CLI expirée' && echo ok || echo ko)"
+check "rappel du tenant dans az login" "ok" "$(diagnose 'AADSTS70043' | grep -q "$AZ_TENANT_ID" && echo ok || echo ko)"
+check "MFA requis"                  "ok" "$(diagnose 'AADSTS50076: due to a configuration change made by your administrator' | grep -q 'authentification forte' && echo ok || echo ko)"
+check "durée refusée par la politique" "ok" "$(diagnose 'RoleAssignmentRequestPolicyValidationFailed' | grep -q 'DEFAULT_DURATION_HOURS' && echo ok || echo ko)"
+check "détail brut toujours affiché" "ok" "$(diagnose 'Erreur inconnue XYZ' | grep -q 'Erreur inconnue XYZ' && echo ok || echo ko)"
+
+printf '\n'
+if (( fails == 0 )); then
+    printf 'RESULTAT: tous les cas OK\n'
+else
+    printf 'RESULTAT: %d cas en echec\n' "$fails"
+fi
+exit $(( fails > 0 ))

--- a/pimMe/tests/test_activation.sh
+++ b/pimMe/tests/test_activation.sh
@@ -88,7 +88,6 @@ check "payload illisible -> vide" ""          "$(_jwt_oid 'pas-du-base64!!')"
 
 printf '\n=== Statut de la demande ===\n'
 
-SCOPE="azure"
 check "ARM : .properties.status"  "Provisioned" "$(_request_status <<<'{"properties":{"status":"Provisioned"}}')"
 check "ARM : statut absent"       ""            "$(_request_status <<<'{"properties":{}}')"
 
@@ -188,10 +187,16 @@ check "n -> quitte"                 "1" "$(prompt_retry_or_quit < <(printf 'n\n'
 check "q -> quitte"                 "1" "$(prompt_retry_or_quit < <(printf 'q\n') >/dev/null 2>&1; echo $?)"
 check "EOF -> quitte (pas de boucle infinie)" "1" "$(prompt_retry_or_quit < /dev/null >/dev/null 2>&1; echo $?)"
 
-printf '\n=== Périmètre : entra retiré ===\n'
+printf '\n=== Périmètre : entra retiré, --scope retiré ===\n'
 
-check "azure accepté"               "0" "$(validate_scope azure >/dev/null 2>&1; echo $?)"
-check "entra refusé"                "1" "$(validate_scope entra >/dev/null 2>&1; echo $?)"
+# Le périmètre n'est plus un choix : plus de flag, plus de variable, plus de
+# validateur. Ce qui reste à vérifier, c'est qu'aucune trace ne subsiste.
+check "aucune option --scope"       "0" \
+    "$(grep -c -e '--scope' -e '\-s|' "$TARGET")"
+check "aucun validate_scope"        "ko" \
+    "$(declare -f validate_scope >/dev/null 2>&1 && echo ok || echo ko)"
+check "aucune variable SCOPE"       "0" \
+    "$(grep -c '^SCOPE=' "$TARGET")"
 check "aucune URL Graph dans le script" "0" \
     "$(grep -c 'graph\.microsoft\.com' "$TARGET")"
 check "aucune soumission Entra"     "ko" \

--- a/pimMe/tests/test_activation.sh
+++ b/pimMe/tests/test_activation.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 #
-# tests/test_activation.sh — Tests du flux d'activation (pim-activate.sh, goal 3).
+# tests/test_activation.sh — Tests du flux d'activation et de la boucle
+# principale (pim-activate.sh, goals 3 et 4).
 #
-# Couvre tout ce qui est déterminable hors ligne : construction des corps de
+# Couvre tout ce qui est déterminable hors ligne : construction du corps de
 # requête, décodage de la claim `oid`, lecture du statut de la demande, prompt
-# de justification, diagnostic des erreurs az. Aucun appel réseau — la
-# soumission réelle et le polling se valident sur un tenant (cf. goal 3).
+# de justification (régime standard et régime obligatoire), règle des rôles
+# sensibles, drapeau d'interruption, relance après échec. Aucun appel réseau —
+# la soumission réelle et le polling se valident sur un tenant (cf. goal 3/4).
 #
 # Usage :
 #   bash tests/test_activation.sh
@@ -33,17 +35,25 @@ check() {
     fi
 }
 
-# Jeu de données : un rôle Azure (scope ARM) et un rôle Entra (scope annuaire).
-ROLE_LABELS=("Owner — subscription SandBox" "Global Reader — annuaire tenant")
+# Jeu de données : trois rôles Azure — un sensible reconnu par GUID, un
+# sensible reconnu par nom seul, un ordinaire.
+ROLE_LABELS=(
+    "Owner — subscription SandBox"
+    "User Access Administrator — subscription SandBox"
+    "Reader — subscription SandBox"
+)
 ROLE_DEFINITION_IDS=(
     "/subscriptions/0000/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
-    "f2ef992c-3afb-46b9-b7cf-a126ee74c451"
+    "/subscriptions/0000/providers/Microsoft.Authorization/roleDefinitions/99999999-9999-9999-9999-999999999999"
+    "/subscriptions/0000/providers/Microsoft.Authorization/roleDefinitions/acdd72a7-3385-48ef-bd42-f606fba81ae7"
 )
-ROLE_SCOPES=("/subscriptions/0000" "/")
+ROLE_SCOPES=("/subscriptions/0000" "/subscriptions/0000" "/subscriptions/0000")
 ROLE_SCHEDULE_IDS=(
     "/subscriptions/0000/providers/Microsoft.Authorization/roleEligibilitySchedules/abcd"
-    "sched-entra-1"
+    "/subscriptions/0000/providers/Microsoft.Authorization/roleEligibilitySchedules/efgh"
+    "/subscriptions/0000/providers/Microsoft.Authorization/roleEligibilitySchedules/ijkl"
 )
+ROLE_NAMES=("Owner" "User Access Administrator" "Reader")
 
 AZ_PRINCIPAL_ID="11111111-2222-3333-4444-555555555555"
 # Volontairement piégeuse : guillemets, apostrophe, accents, backslash.
@@ -65,17 +75,6 @@ check "linked absent par défaut"          "null" "$(jq -r '.properties.linkedRo
 body="$(_azure_activation_body 0 "${ROLE_SCHEDULE_IDS[0]}")"
 check "linked présent au 2e essai"        "${ROLE_SCHEDULE_IDS[0]}" "$(jq -r '.properties.linkedRoleEligibilityScheduleId' <<<"$body")"
 
-printf '\n=== Corps de requête Entra (Graph) ===\n'
-
-body="$(_entra_activation_body 1)"
-check "JSON valide"                       "ok" "$(jq -e . >/dev/null 2>&1 <<<"$body" && echo ok || echo ko)"
-check "action selfActivate"               "selfActivate" "$(jq -r '.action' <<<"$body")"
-check "directoryScopeId depuis ROLE_SCOPES" "/" "$(jq -r '.directoryScopeId' <<<"$body")"
-check "roleDefinitionId nu (pas de chemin ARM)" "${ROLE_DEFINITION_IDS[1]}" "$(jq -r '.roleDefinitionId' <<<"$body")"
-# Graph refuse la casse ARM : afterDuration, pas AfterDuration.
-check "expiration.type camelCase"         "afterDuration" "$(jq -r '.scheduleInfo.expiration.type' <<<"$body")"
-check "pas d'enveloppe properties"        "null" "$(jq -r '.properties // "null"' <<<"$body")"
-
 printf '\n=== Claim oid du jeton ARM ===\n'
 
 # Payload base64url sans padding, avec un `_` et un `-` dans le corps encodé.
@@ -92,9 +91,6 @@ printf '\n=== Statut de la demande ===\n'
 SCOPE="azure"
 check "ARM : .properties.status"  "Provisioned" "$(_request_status <<<'{"properties":{"status":"Provisioned"}}')"
 check "ARM : statut absent"       ""            "$(_request_status <<<'{"properties":{}}')"
-SCOPE="entra"
-check "Graph : .status"           "Granted"     "$(_request_status <<<'{"status":"Granted","id":"x"}')"
-SCOPE="azure"
 
 printf '\n=== GUID de demande ===\n'
 
@@ -124,6 +120,83 @@ prompt_justification < /dev/null >/dev/null 2>&1; rc=$?
 check "EOF -> annulation"           "$MENU_CANCELLED" "$rc"
 check "EOF -> rien à soumettre"     "" "$JUSTIFICATION"
 
+printf '\n=== Rôles à justification obligatoire ===\n'
+
+check "Owner (GUID intégré)"        "ok" "$(justification_is_mandatory 0 && echo ok || echo ko)"
+check "User Access Administrator (nom)" "ok" "$(justification_is_mandatory 1 && echo ok || echo ko)"
+check "Reader ordinaire"            "ko" "$(justification_is_mandatory 2 && echo ok || echo ko)"
+
+# Nom absent de l'API : le GUID doit suffire, et inversement.
+saved_names=("${ROLE_NAMES[@]}")
+ROLE_NAMES=("" "" "")
+check "Owner sans displayName"      "ok" "$(justification_is_mandatory 0 && echo ok || echo ko)"
+check "UAA sans displayName ni GUID connu" "ko" "$(justification_is_mandatory 1 && echo ok || echo ko)"
+ROLE_NAMES=("${saved_names[@]}")
+
+# Casse et espaces : le nom vient de l'API, on ne suppose rien.
+ROLE_NAMES[2]="OWNER"
+check "nom insensible à la casse"   "ok" "$(justification_is_mandatory 2 && echo ok || echo ko)"
+ROLE_NAMES[2]="Reader"
+
+printf '\n=== Prompt de justification obligatoire ===\n'
+
+# Rôle sensible : rien de pré-rempli (prefill vide) et refus des lignes vides.
+JUSTIFICATION="sentinelle"
+prompt_justification 0 < <(printf 'Escalade incident P1\n') >/dev/null 2>&1; rc=$?
+check "rôle sensible : texte accepté" "0" "$rc"
+check "rôle sensible : texte retenu"  "Escalade incident P1" "$JUSTIFICATION"
+
+# Deux lignes vides puis un motif : les vides sont refusées, la saisie continue.
+# Sortie capturée dans un FICHIER et non par substitution : un sous-shell
+# perdrait l'écriture de $JUSTIFICATION (cf. note plus haut).
+out_file="$(mktemp)"
+JUSTIFICATION="sentinelle"
+prompt_justification 0 < <(printf '\n   \n Motif réel \n') >"$out_file" 2>&1; rc=$?
+check "rôle sensible : vides refusées puis motif" "0" "$rc"
+check "rôle sensible : motif rogné"   "Motif réel" "$JUSTIFICATION"
+check "rôle sensible : refus signalé" "2" "$(grep -c 'Justification obligatoire pour ce rôle' "$out_file")"
+
+# Jamais de placeholder soumis en douce : sur EOF sans saisie, rien ne part.
+JUSTIFICATION="sentinelle"
+prompt_justification 0 < /dev/null >/dev/null 2>&1; rc=$?
+check "rôle sensible : EOF -> annulation" "$MENU_CANCELLED" "$rc"
+check "rôle sensible : rien à soumettre"  "" "$JUSTIFICATION"
+
+# Le placeholder du régime standard ne doit pas fuiter dans le régime strict.
+prompt_justification 0 < <(printf 'X\n') >"$out_file" 2>&1
+check "rôle sensible : pas de placeholder affiché" "0" "$(grep -c "$DEFAULT_JUSTIFICATION" "$out_file")"
+check "rôle sensible : mention obligatoire"        "1" "$(grep -c 'justification obligatoire' "$out_file")"
+rm -f "$out_file"
+
+printf '\n=== Interruption (Ctrl+C) ===\n'
+
+INTERRUPTED=0
+check "drapeau au repos"            "1" "$(take_interrupt; echo $?)"
+INTERRUPTED=1
+check "drapeau levé -> consommé"    "0" "$(take_interrupt; echo $?)"
+INTERRUPTED=1
+take_interrupt
+check "consommation remet à zéro"   "0" "$INTERRUPTED"
+check "code distinct de l annulation" "ok" \
+    "$([[ "$ACTIVATION_INTERRUPTED" != "$MENU_CANCELLED" && "$ACTIVATION_INTERRUPTED" -lt 128 ]] && echo ok || echo ko)"
+
+printf '\n=== Relance après échec de listing ===\n'
+
+check "Entrée -> recharge"          "0" "$(prompt_retry_or_quit < <(printf '\n') >/dev/null 2>&1; echo $?)"
+check "o -> recharge"               "0" "$(prompt_retry_or_quit < <(printf 'o\n') >/dev/null 2>&1; echo $?)"
+check "n -> quitte"                 "1" "$(prompt_retry_or_quit < <(printf 'n\n') >/dev/null 2>&1; echo $?)"
+check "q -> quitte"                 "1" "$(prompt_retry_or_quit < <(printf 'q\n') >/dev/null 2>&1; echo $?)"
+check "EOF -> quitte (pas de boucle infinie)" "1" "$(prompt_retry_or_quit < /dev/null >/dev/null 2>&1; echo $?)"
+
+printf '\n=== Périmètre : entra retiré ===\n'
+
+check "azure accepté"               "0" "$(validate_scope azure >/dev/null 2>&1; echo $?)"
+check "entra refusé"                "1" "$(validate_scope entra >/dev/null 2>&1; echo $?)"
+check "aucune URL Graph dans le script" "0" \
+    "$(grep -c 'graph\.microsoft\.com' "$TARGET")"
+check "aucune soumission Entra"     "ko" \
+    "$(declare -f submit_entra_activation >/dev/null 2>&1 && echo ok || echo ko)"
+
 printf '\n=== Diagnostic des erreurs az ===\n'
 
 AZ_REST_ERROR_FILE="$(mktemp)"
@@ -138,8 +211,12 @@ check "consentement Graph manquant" "ok" "$(diagnose 'ERROR: PermissionScopeNotG
 check "session expirée (AADSTS70043)" "ok" "$(diagnose 'SubError: token_expired AADSTS70043: refresh token expired' | grep -q 'Session Azure CLI expirée' && echo ok || echo ko)"
 check "rappel du tenant dans az login" "ok" "$(diagnose 'AADSTS70043' | grep -q "$AZ_TENANT_ID" && echo ok || echo ko)"
 check "MFA requis"                  "ok" "$(diagnose 'AADSTS50076: due to a configuration change made by your administrator' | grep -q 'authentification forte' && echo ok || echo ko)"
+check "rôle déjà actif"             "ok" "$(diagnose 'ERROR: Bad Request({"error":{"code":"RoleAssignmentExists","message":"The Role assignment already exists."}})' | grep -q 'déjà actif' && echo ok || echo ko)"
 check "durée refusée par la politique" "ok" "$(diagnose 'RoleAssignmentRequestPolicyValidationFailed' | grep -q 'DEFAULT_DURATION_HOURS' && echo ok || echo ko)"
 check "détail brut toujours affiché" "ok" "$(diagnose 'Erreur inconnue XYZ' | grep -q 'Erreur inconnue XYZ' && echo ok || echo ko)"
+# Panne réseau : le message doit rester lisible et parler connectivité.
+check "réseau injoignable (DNS)"    "ok" "$(diagnose "urllib3 ... Failed to establish a new connection: [Errno -3] Temporary failure in name resolution" | grep -q 'réseau ou le service ne répond pas' && echo ok || echo ko)"
+check "réseau injoignable (timeout)" "ok" "$(diagnose 'HTTPSConnectionPool(host=management.azure.com): Read timed out. (read timeout=300)' | grep -q 'réseau ou le service ne répond pas' && echo ok || echo ko)"
 
 printf '\n'
 if (( fails == 0 )); then

--- a/pimMe/tests/test_interrupt.sh
+++ b/pimMe/tests/test_interrupt.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# tests/test_interrupt.sh — Ctrl+C et état du terminal (pim-activate.sh, goal 4).
+#
+# Le signal est envoyé au GROUPE de processus, exactement comme le fait un
+# terminal sur Ctrl+C : la cible est lancée via `setsid` pour disposer de son
+# propre groupe, et `kill -INT -$pgid` frappe le script ET l'`az` qu'il attend.
+#
+# Situations couvertes :
+#   A. interruption pendant le polling (poll_activation, appels az réels) ;
+#   B. interruption pendant l'attente clavier du menu ;
+#   C. interruption pendant la saisie de la justification ;
+#   D. réglages tty et curseur après interruption (terminal non cassé).
+#
+# Usage :
+#   bash tests/test_interrupt.sh
+#
+set -uo pipefail
+
+# Job control obligatoire : sans lui, bash lance les tâches d'arrière-plan avec
+# SIGINT *ignoré*, et un signal ignoré à l'entrée d'un shell ne peut plus y être
+# trappé — le script testé ne verrait jamais le Ctrl+C simulé. En usage réel il
+# tourne au premier plan d'un terminal, où le signal arrive normalement.
+set -m
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${TEST_DIR}/../pim-activate.sh"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fails=0
+check() {
+    local label="$1" expected="$2" got="$3"
+    if [[ "$got" == "$expected" ]]; then
+        printf 'PASS  %-50s -> %s\n' "$label" "$got"
+    else
+        printf 'FAIL  %-50s -> attendu "%s", obtenu "%s"\n' "$label" "$expected" "$got"
+        fails=$((fails + 1))
+    fi
+}
+
+CHILD_PGID=""
+CHILD_JOB=""
+
+# Lance une commande dans sa propre session (donc son propre groupe), stdin
+# branché sur $1 (fifo ou /dev/null), sortie fusionnée dans $2.
+spawn_child() {
+    local stdin_path="$1" log="$2"; shift 2
+    local pidfile="${WORK}/pgid"
+
+    : > "$log"
+    rm -f "$pidfile"
+    setsid bash -c 'echo $$ > "$0"; exec "${@:3}" < "$1" > "$2" 2>&1' \
+        "$pidfile" "$stdin_path" "$log" "$@" &
+    CHILD_JOB=$!
+
+    local waited=0
+    while [[ ! -s "$pidfile" ]] && (( waited < 100 )); do
+        sleep 0.1; waited=$((waited + 1))
+    done
+    CHILD_PGID="$(cat "$pidfile" 2>/dev/null)"
+    [[ -n "$CHILD_PGID" ]]
+}
+
+# Attend l'apparition d'un motif dans le log (timeout en secondes).
+wait_for() {
+    local log="$1" pattern="$2" limit="${3:-60}" waited=0
+    while (( waited < limit * 2 )); do
+        grep -q "$pattern" "$log" 2>/dev/null && return 0
+        sleep 0.5; waited=$((waited + 1))
+    done
+    return 1
+}
+
+interrupt_child() {
+    kill -INT -"$CHILD_PGID" 2>/dev/null \
+        || printf 'ATTENTION : signal non délivré au groupe %s\n' "$CHILD_PGID" >&2
+}
+
+printf '=== A. Ctrl+C pendant le polling (appels az réels) ===\n'
+
+# Runner : le vrai poll_activation, sur une demande d'activation inexistante.
+# Chaque GET échoue sans statut terminal : la boucle tourne jusqu'au timeout de
+# 60s — fenêtre large et déterministe pour recevoir le signal.
+cat > "${WORK}/poll_runner.sh" <<RUNNER
+#!/usr/bin/env bash
+source "${TARGET}"
+install_signal_traps
+init_az_rest_error_file
+POLL_URL="https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Authorization/roleAssignmentScheduleRequests/11111111-1111-1111-1111-111111111111?api-version=2020-10-01"
+rc=0
+poll_activation || rc=\$?
+printf 'RC=%s\n' "\$rc"
+RUNNER
+
+log="${WORK}/poll.log"
+spawn_child /dev/null "$log" bash "${WORK}/poll_runner.sh"
+wait_for "$log" 'Attente du provisionnement' 30
+sleep 2
+start=$SECONDS
+interrupt_child
+wait "$CHILD_JOB"
+elapsed=$(( SECONDS - start ))
+
+check "message d'interruption affiché" "1" "$(grep -c 'Attente interrompue' "$log")"
+check "demande signalée comme soumise"  "1" "$(grep -c 'reste soumise côté Azure' "$log")"
+check "code ACTIVATION_INTERRUPTED"     "RC=65" "$(grep -m1 '^RC=' "$log")"
+check "sortie immédiate, pas au timeout" "ok" "$( (( elapsed < 20 )) && echo ok || echo ko)"
+check "pas de trace set -e brute"       "0" "$(grep -c ': line [0-9]*:' "$log")"
+
+printf '\n=== B. Ctrl+C pendant l attente clavier du menu ===\n'
+
+fifo="${WORK}/in.b"; mkfifo "$fifo"
+log="${WORK}/menu.log"
+# Ouverture en lecture-écriture : `exec 9>fifo` seul bloquerait jusqu'à ce
+# qu'un lecteur se présente.
+exec 9<>"$fifo"
+spawn_child "$fifo" "$log" "$TARGET"
+wait_for "$log" 'q pour annuler' 90
+interrupt_child
+wait_for "$log" 'Interruption (Ctrl+C)' 30
+# Le menu est réaffiché après rechargement : q quitte alors.
+wait_for "$log" 'Chargement des rôles eligible.*\n.*' 5
+printf 'q' >&9
+wait "$CHILD_JOB"; rc_b=$?
+exec 9>&-
+
+check "interruption signalée"           "1" "$(grep -c 'Interruption (Ctrl+C) — retour à la liste' "$log")"
+check "liste rechargée après le signal"  "ok" \
+    "$( (( $(grep -c 'Chargement des rôles eligible' "$log") >= 2 )) && echo ok || echo ko)"
+check "q quitte ensuite proprement"      "1" "$(grep -c '^Sortie\.' "$log")"
+check "code de sortie 0"                 "0" "$rc_b"
+
+printf '\n=== C. Ctrl+C pendant la saisie de la justification ===\n'
+
+fifo="${WORK}/in.c"; mkfifo "$fifo"
+log="${WORK}/just.log"
+exec 9<>"$fifo"
+spawn_child "$fifo" "$log" "$TARGET"
+wait_for "$log" 'q pour annuler' 90
+printf '1\n' >&9
+wait_for "$log" 'Justification' 30
+interrupt_child
+wait_for "$log" 'Activation abandonnée avant soumission' 30
+printf 'q' >&9
+wait "$CHILD_JOB"; rc_c=$?
+exec 9>&-
+
+check "saisie interrompue signalée"      "1" "$(grep -c 'Interruption (Ctrl+C)' "$log")"
+check "abandon avant soumission"         "1" "$(grep -c 'Activation abandonnée avant soumission' "$log")"
+check "aucune demande soumise"           "0" "$(grep -c 'Soumission de la demande' "$log")"
+check "retour à la liste"                "ok" \
+    "$( (( $(grep -c 'Chargement des rôles eligible' "$log") >= 2 )) && echo ok || echo ko)"
+check "code de sortie 0"                 "0" "$rc_c"
+
+printf '\n=== D. État du terminal après interruption ===\n'
+
+# Le seul test qui exige un VRAI terminal : `read -rsn1` bascule le tty en
+# raw/-echo, et c'est cet état-là qu'une interruption pourrait laisser derrière
+# elle. Un pty est fourni par python3 (script(1) ferait aussi l'affaire mais
+# n'est pas installé partout) ; à défaut, le cas est sauté, pas silencieusement
+# déclaré vert.
+if command -v python3 >/dev/null 2>&1; then
+    cat > "${WORK}/pty_driver.py" <<'PYDRV'
+"""Lance une commande dans un pty, envoie SIGINT quand un motif apparaît, puis
+tape 'q'. Sortie du pty recopiée sur stdout. argv: <log> <cmd...>"""
+import os, pty, re, signal, sys, time
+
+log_path, cmd = sys.argv[1], sys.argv[2:]
+pid, fd = pty.fork()
+if pid == 0:
+    os.execvp(cmd[0], cmd)
+
+buf, sent_int, sent_q, deadline = b"", False, False, time.time() + 180
+while time.time() < deadline:
+    try:
+        chunk = os.read(fd, 4096)
+    except OSError:
+        break
+    if not chunk:
+        break
+    buf += chunk
+    menus = buf.count(b"q pour annuler")
+    if not sent_int and menus >= 1:
+        time.sleep(1)
+        os.killpg(os.getpgid(pid), signal.SIGINT)
+        sent_int = True
+    elif sent_int and not sent_q and menus >= 2:
+        time.sleep(1)
+        os.write(fd, b"q")
+        sent_q = True
+os.close(fd)
+os.waitpid(pid, 0)
+open(log_path, "wb").write(buf)
+PYDRV
+
+    ptylog="${WORK}/pty.log"
+    # stty avant/après DANS le pty : c'est l'état du terminal du script qui est
+    # en jeu, pas celui du shell de test.
+    python3 "${WORK}/pty_driver.py" "$ptylog" \
+        bash -c "stty -g > '${WORK}/tty.before'; '${TARGET}'; stty -g > '${WORK}/tty.after'" \
+        >/dev/null 2>&1
+
+    check "tty restauré à l'identique après Ctrl+C" "ok" \
+        "$(cmp -s "${WORK}/tty.before" "${WORK}/tty.after" && echo ok || echo ko)"
+    check "écho réactivé (pas de -echo résiduel)"    "ok" \
+        "$(grep -q -- '-echo' "${WORK}/tty.after" && echo ko || echo ok)"
+    check "interruption vue dans le pty"             "ok" \
+        "$(grep -q 'Interruption (Ctrl+C)' "$ptylog" && echo ok || echo ko)"
+    check "curseur réaffiché (ESC[?25h)"             "ok" \
+        "$(grep -q $'\033\[?25h' "$ptylog" && echo ok || echo ko)"
+    check "sortie propre par q"                      "ok" \
+        "$(grep -q 'Sortie\.' "$ptylog" && echo ok || echo ko)"
+else
+    printf 'SKIP  python3 absent : test pty non exécuté\n'
+fi
+
+printf '\n'
+if (( fails == 0 )); then
+    printf 'RESULTAT: tous les cas OK\n'
+else
+    printf 'RESULTAT: %d cas en echec\n' "$fails"
+fi
+exit $(( fails > 0 ))

--- a/pimMe/tests/test_menu.sh
+++ b/pimMe/tests/test_menu.sh
@@ -79,7 +79,7 @@ run_case "0 (hors borne) puis 2"            '0\n2\n'                     1
 run_case "1 backspace 4 puis Entree"        '1\177 4\n'                  3
 run_case "bas puis numero 4"                '\033[B4\n'                  3
 
-printf '\n=== Touches d action (goal 2 : bascule de scope) ===\n'
+printf '\n=== Touches d action (goal 4 : r = recharger la liste) ===\n'
 # run_case ne sert pas ici : on doit lire A LA FOIS stdout (la touche) et le
 # code retour, sur une fonction qui renvoie normalement un index.
 run_hotkey() {

--- a/pimMe/tests/test_menu.sh
+++ b/pimMe/tests/test_menu.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# tests/test_menu.sh — Tests de select_from_menu (pim-activate.sh, goal 1).
+#
+# Deux étages :
+#   1. Suite automatique : stdin alimenté par pipe, stderr redirigé. Couvre la
+#      logique de sélection (flèches, numéro, annulation, cas limites). Tourne
+#      partout, y compris sans terminal.
+#   2. Suite interactive : stdin ET stderr sur le vrai terminal. Seule façon de
+#      valider le redessin ANSI in-place — la branche `[[ -t 2 ]]` de
+#      _menu_render est inatteignable derrière un pipe. Auto-skippée hors TTY.
+#
+# Usage :
+#   bash tests/test_menu.sh          # auto + interactif (si terminal)
+#   bash tests/test_menu.sh --auto   # suite automatique seule
+#
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${TEST_DIR}/../pim-activate.sh"
+
+# shellcheck source=../pim-activate.sh
+source "$TARGET"
+# pim-activate.sh pose `set -euo pipefail` en se sourçant : on relâche -e, le
+# harnais teste justement des retours non-zéro.
+set +e
+
+OPTS=("Contributor / sub-prod" "Owner / sub-dev" "Global Reader" "User Administrator")
+fails=0
+ONLY_AUTO=0
+[[ "${1:-}" == "--auto" ]] && ONLY_AUTO=1
+
+# ---------------------------------------------------------------------------
+# 1. Suite automatique (pipe)
+# ---------------------------------------------------------------------------
+
+run_case() {
+    local label="$1" keys="$2" exp_idx="$3" exp_rc="${4:-0}" got rc
+    got="$(printf '%b' "$keys" | select_from_menu "Choisir un rôle :" "${OPTS[@]}" 2>/dev/null)"
+    rc=$?
+    if [[ "$got" == "$exp_idx" && $rc -eq $exp_rc ]]; then
+        if [[ -n "$got" ]]; then
+            printf 'PASS  %-42s -> index %s (%s)\n' "$label" "$got" "${OPTS[$got]}"
+        else
+            printf 'PASS  %-42s -> aucune selection, rc=%s\n' "$label" "$rc"
+        fi
+    else
+        printf 'FAIL  %-42s -> attendu idx="%s" rc=%s, obtenu idx="%s" rc=%s\n' \
+            "$label" "$exp_idx" "$exp_rc" "$got" "$rc"
+        fails=$((fails + 1))
+    fi
+}
+
+printf '=== Rendu hors TTY (4 entrees factices) ===\n'
+printf '\n' | select_from_menu "Choisir un rôle :" "${OPTS[@]}" >/dev/null
+printf '\n\n'
+
+printf '=== Fleches ===\n'
+run_case "bas, bas, Entree"                 '\033[B\033[B\n'             2
+run_case "haut (bouclage), Entree"          '\033[A\n'                   3
+run_case "bas x3, haut, Entree"             '\033[B\033[B\033[B\033[A\n' 2
+run_case "bas x4 (bouclage complet)"        '\033[B\033[B\033[B\033[B\n' 0
+run_case "Entree directe (defaut)"          '\n'                         0
+
+printf '\n=== Numero ===\n'
+run_case "4 puis Entree"                    '4\n'                        3
+run_case "2 puis Entree"                    '2\n'                        1
+run_case "1 puis Entree"                    '1\n'                        0
+
+printf '\n=== Annulation (sentinel %s) ===\n' "$MENU_CANCELLED"
+run_case "q immediat"                       'q'                          "" "$MENU_CANCELLED"
+run_case "Q majuscule"                      'Q'                          "" "$MENU_CANCELLED"
+run_case "bas, bas puis q"                  '\033[B\033[B q'             "" "$MENU_CANCELLED"
+run_case "EOF (Ctrl-D)"                     ''                           "" "$MENU_CANCELLED"
+
+printf '\n=== Cas limites ===\n'
+run_case "9 (hors borne) puis 3"            '9\n3\n'                     2
+run_case "0 (hors borne) puis 2"            '0\n2\n'                     1
+run_case "1 backspace 4 puis Entree"        '1\177 4\n'                  3
+run_case "bas puis numero 4"                '\033[B4\n'                  3
+
+printf '\n=== Contrat d appel ===\n'
+# Le sentinel ne doit pas retomber dans la plage des signaux (128+N) : le trap
+# Ctrl+C du goal 4 doit rester distinguable d une annulation de menu.
+if (( MENU_CANCELLED >= 128 || MENU_CANCELLED == 126 || MENU_CANCELLED == 127 )); then
+    printf 'FAIL  MENU_CANCELLED=%s empiete sur une plage reservee\n' "$MENU_CANCELLED"
+    fails=$((fails + 1))
+else
+    printf 'PASS  MENU_CANCELLED=%s hors plages reservees (126,127,128+N)\n' "$MENU_CANCELLED"
+fi
+
+if idx="$(printf 'q' | select_from_menu "T" "${OPTS[@]}" 2>/dev/null)"; then
+    printf 'FAIL  q devrait faire echouer la substitution (idx="%s")\n' "$idx"
+    fails=$((fails + 1))
+else
+    rc=$?
+    if (( rc == MENU_CANCELLED )); then
+        printf 'PASS  q -> branche else, rc == $MENU_CANCELLED (%s)\n' "$rc"
+    else
+        printf 'FAIL  rc inattendu apres q : %s\n' "$rc"
+        fails=$((fails + 1))
+    fi
+fi
+
+if select_from_menu "Sans options" </dev/null >/dev/null 2>&1; then
+    printf 'FAIL  menu sans option devrait echouer\n'
+    fails=$((fails + 1))
+else
+    printf 'PASS  menu sans option -> rc=%s\n' "$?"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Suite interactive (TTY requis)
+# ---------------------------------------------------------------------------
+
+confirm() {
+    local question="$1" answer
+    read -r -p "      $question [o/N] " answer
+    [[ "$answer" =~ ^[oOyY]$ ]]
+}
+
+check_manual() {
+    local label="$1"
+    if confirm "$2"; then
+        printf 'PASS  %s\n\n' "$label"
+    else
+        printf 'FAIL  %s\n\n' "$label"
+        fails=$((fails + 1))
+    fi
+}
+
+printf '\n'
+if (( ONLY_AUTO )); then
+    printf '=== Suite interactive : SKIP (--auto) ===\n'
+elif [[ ! -t 0 || ! -t 2 ]]; then
+    printf '=== Suite interactive : SKIP (pas de terminal) ===\n'
+    printf '    Le redessin ANSI in-place reste NON VALIDE.\n'
+    printf '    Relancer depuis un vrai terminal : bash tests/test_menu.sh\n'
+else
+    printf '=== Suite interactive (rendu ANSI reel) ===\n\n'
+
+    printf -- '--- 1/3 : navigation aux fleches ---\n'
+    printf '      Descends puis remonte plusieurs fois, choisis "Global Reader" (3e), Entree.\n\n'
+    idx="$(select_from_menu "Choisir un rôle :" "${OPTS[@]}")"
+    rc=$?
+    printf '\n      Retour : rc=%s idx=%s\n' "$rc" "${idx:-<vide>}"
+    if [[ "$idx" == "2" && $rc -eq 0 ]]; then
+        printf 'PASS  selection fleches -> index 2 (%s)\n' "${OPTS[2]}"
+    else
+        printf 'FAIL  attendu idx=2 rc=0, obtenu idx="%s" rc=%s\n' "$idx" "$rc"
+        fails=$((fails + 1))
+    fi
+    check_manual "redessin ANSI in-place" \
+        "Le menu s est redessine SUR PLACE (pas d empilement de copies) ?"
+    check_manual "surlignage video inverse" \
+        "La ligne courante etait surlignee et le surlignage suivait les fleches ?"
+
+    printf -- '--- 2/3 : saisie numerique + backspace ---\n'
+    printf '      Tape 1, efface au backspace, tape 4, Entree.\n\n'
+    idx="$(select_from_menu "Choisir un rôle :" "${OPTS[@]}")"
+    rc=$?
+    printf '\n      Retour : rc=%s idx=%s\n' "$rc" "${idx:-<vide>}"
+    if [[ "$idx" == "3" && $rc -eq 0 ]]; then
+        printf 'PASS  selection numerique -> index 3 (%s)\n' "${OPTS[3]}"
+    else
+        printf 'FAIL  attendu idx=3 rc=0, obtenu idx="%s" rc=%s\n' "$idx" "$rc"
+        fails=$((fails + 1))
+    fi
+    check_manual "echo de la saisie" \
+        "Les chiffres tapes s affichaient apres l invite, et le backspace les effacait ?"
+
+    printf -- '--- 3/3 : annulation ---\n'
+    printf '      Appuie sur q.\n\n'
+    idx="$(select_from_menu "Choisir un rôle :" "${OPTS[@]}")"
+    rc=$?
+    printf '\n      Retour : rc=%s idx=%s\n' "$rc" "${idx:-<vide>}"
+    if [[ -z "$idx" && $rc -eq $MENU_CANCELLED ]]; then
+        printf 'PASS  annulation -> rc=%s, aucune selection\n\n' "$rc"
+    else
+        printf 'FAIL  attendu idx vide rc=%s, obtenu idx="%s" rc=%s\n\n' "$MENU_CANCELLED" "$idx" "$rc"
+        fails=$((fails + 1))
+    fi
+fi
+
+printf '\n'
+if (( fails == 0 )); then
+    printf 'RESULTAT: tous les cas OK\n'
+else
+    printf 'RESULTAT: %s echec(s)\n' "$fails"
+fi
+exit $fails

--- a/pimMe/tests/test_menu.sh
+++ b/pimMe/tests/test_menu.sh
@@ -79,6 +79,49 @@ run_case "0 (hors borne) puis 2"            '0\n2\n'                     1
 run_case "1 backspace 4 puis Entree"        '1\177 4\n'                  3
 run_case "bas puis numero 4"                '\033[B4\n'                  3
 
+printf '\n=== Touches d action (goal 2 : bascule de scope) ===\n'
+# run_case ne sert pas ici : on doit lire A LA FOIS stdout (la touche) et le
+# code retour, sur une fonction qui renvoie normalement un index.
+run_hotkey() {
+    local label="$1" keys="$2" exp_key="$3" got rc
+    MENU_HOTKEYS=("a" "e")
+    got="$(printf '%b' "$keys" | select_from_menu "Choisir :" "${OPTS[@]}" 2>/dev/null)"
+    rc=$?
+    MENU_HOTKEYS=()
+    if [[ "$got" == "$exp_key" && $rc -eq $MENU_HOTKEY_PRESSED ]]; then
+        printf 'PASS  %-42s -> touche "%s", rc=%s\n' "$label" "$got" "$rc"
+    else
+        printf 'FAIL  %-42s -> attendu "%s"/rc=%s, obtenu "%s"/rc=%s\n' \
+            "$label" "$exp_key" "$MENU_HOTKEY_PRESSED" "$got" "$rc"
+        fails=$((fails + 1))
+    fi
+}
+
+run_hotkey "a immediat"                     'a'              a
+run_hotkey "e immediat"                     'e'              e
+run_hotkey "apres navigation (bas, bas, e)" '\033[B\033[B e' e
+run_hotkey "apres saisie partielle (1 puis a)" '1a'          a
+
+# Hors liste de hotkeys, la touche doit etre ignoree, pas interceptee.
+MENU_HOTKEYS=("a" "e")
+got="$(printf 'z2\n' | select_from_menu "Choisir :" "${OPTS[@]}" 2>/dev/null)"; rc=$?
+MENU_HOTKEYS=()
+if [[ "$got" == "1" && $rc -eq 0 ]]; then
+    printf 'PASS  %-42s -> index 1\n' "touche hors liste (z) ignoree"
+else
+    printf 'FAIL  %-42s -> attendu idx=1 rc=0, obtenu "%s"/rc=%s\n' "touche hors liste (z) ignoree" "$got" "$rc"
+    fails=$((fails + 1))
+fi
+
+# Sans hotkeys declarees, le contrat du goal 1 doit etre strictement inchange.
+got="$(printf 'a2\n' | select_from_menu "Choisir :" "${OPTS[@]}" 2>/dev/null)"; rc=$?
+if [[ "$got" == "1" && $rc -eq 0 ]]; then
+    printf 'PASS  %-42s -> index 1\n' "MENU_HOTKEYS vide : a sans effet"
+else
+    printf 'FAIL  %-42s -> attendu idx=1 rc=0, obtenu "%s"/rc=%s\n' "MENU_HOTKEYS vide : a sans effet" "$got" "$rc"
+    fails=$((fails + 1))
+fi
+
 printf '\n=== Contrat d appel ===\n'
 # Le sentinel ne doit pas retomber dans la plage des signaux (128+N) : le trap
 # Ctrl+C du goal 4 doit rester distinguable d une annulation de menu.


### PR DESCRIPTION
## Résumé

Script bash interactif d'activation de rôles PIM de ressources Azure, alternative rapide au portail. Série des 4 goals de `pimMe/plan.md`, du squelette à la boucle complète.

- `chore` — ignore les artefacts `Zone.Identifier` de WSL
- `docs(pimMe)` — plan et découpage en 4 goals
- `feat(pimMe)` — fondations : check `az`/`jq`, check de session, parsing d'arguments, menu réutilisable en bash pur (flèches, numéro, `q`)
- `feat(pimMe)` — listing des rôles éligibles (ARM, scope racine + `asTarget()`)
- `feat(pimMe)` — justification, soumission `SelfActivate`, polling jusqu'à `Provisioned`
- `feat(pimMe)!` — boucle principale, gestion d'erreurs globale, `Ctrl+C` trappé, retrait du scope Entra
- `docs(pimMe)` — README avec un exemple d'exécution réel

## Points d'attention

**BREAKING CHANGE** : `--scope entra` est refusé. Le chemin Graph (listing et activation des rôles d'annuaire) a été retiré ; seul ARM est appelé. Le commit `c46c18d` mentionne une bascule de scope `a`/`e` qui n'existe plus — la touche d'action du menu sert désormais à recharger la liste (`r`).

**Justification obligatoire** sur `Owner` et `User Access Administrator` : aucun texte pré-rempli, ligne vide refusée.

**Ctrl+C** : bash quitte un script quand un signal frappe le builtin `read` du shell principal, trap ou pas. Toutes les saisies passent donc par une substitution de commande — le sous-shell meurt, le script survit et revient à la liste, terminal restauré.

## Validation

Déroulé sur un tenant réel : cycle complet lister → activer → retour liste → activer un second rôle → `q` (deux `Provisioned`), panne réseau simulée (message clair, retour au menu, pas de crash), `Ctrl+C` pendant polling / menu / saisie.

```
bash pimMe/tests/test_menu.sh         # navigation, saisie, annulation, hotkeys
bash pimMe/tests/test_activation.sh   # corps de requête, justification, diagnostics
bash pimMe/tests/test_interrupt.sh    # SIGINT réel au groupe de processus + état du tty
```

Les trois suites passent. `test_interrupt.sh` émet de vrais appels `az` et n'active aucun rôle.

## Revue
- [ ] Changements validés
- [ ] Tests passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGQgbF2QAbUz9JgjZB9cgf