### PR TITLE
feat(pimMe)!: read the activation duration from the role's pim policy

### DIFF
--- a/pimMe/README.md
+++ b/pimMe/README.md
@@ -49,9 +49,10 @@ Rôle sélectionné :
 
 Justification (Entrée valide, ligne vide annule) : Validation goal 4 - premier role du cycle
 
-Soumission de la demande (8h)…
+Durée retenue : 8 h (policy du rôle, maximumDuration PT8H).
+Soumission de la demande (8 h)…
 Attente du provisionnement .
-Rôle activé (Provisioned) pour 8h.
+Rôle activé (Provisioned) pour 8 h.
 Chargement des rôles eligible…            ← retour automatique
 Rôles eligible (19) — Entrée active, r recharge, q quitte :
 …
@@ -65,9 +66,10 @@ Justification obligatoire (Ctrl+C annule) :
 Erreur : Justification obligatoire pour ce rôle : saisissez un motif (Ctrl+C pour annuler).
 Justification obligatoire (Ctrl+C annule) : Revue des acces LZ-CPAS - demande utilisateur
 
-Soumission de la demande (8h)…
+Durée retenue : 8 h (policy du rôle, maximumDuration PT8H).
+Soumission de la demande (8 h)…
 Attente du provisionnement .
-Rôle activé (Provisioned) pour 8h.
+Rôle activé (Provisioned) pour 8 h.
 Chargement des rôles eligible…
 Rôles eligible (19) — Entrée active, r recharge, q quitte :
 q
@@ -75,6 +77,23 @@ Sortie.
 $ echo $?
 0
 ```
+
+### Durée d'activation
+
+La durée maximale autorisée est propre à chaque rôle **et** à chaque scope : sur
+ce tenant elle vaut 4 h, 8 h ou 9 h selon le couple. Avant chaque soumission, le
+script lit la policy PIM du rôle choisi
+(`roleManagementPolicyAssignments`, règle `Expiration_EndUser_Assignment`),
+retient son `maximumDuration` et l'affiche :
+
+```
+Durée retenue : 4 h (policy du rôle, maximumDuration PT4H).
+Soumission de la demande (4 h)…
+```
+
+Un seul appel de policy par activation. Si la lecture échoue, le script se
+replie sur `FALLBACK_DURATION_HOURS` (1 h) et le dit, plutôt que d'abandonner
+l'activation.
 
 ### Justification
 
@@ -90,7 +109,8 @@ déjà actif) est traduit en message actionnable, suivi du détail brut, puis
 ramène à la liste :
 
 ```
-Soumission de la demande (8h)…
+Durée retenue : 8 h (policy du rôle, maximumDuration PT8H).
+Soumission de la demande (8 h)…
 Erreur : Échec de la soumission de l'activation Azure.
 Erreur : Appel Azure impossible : le réseau ou le service ne répond pas.
 Erreur : Vérifiez la connectivité (proxy, VPN, DNS) puis rechargez la liste.

--- a/pimMe/pim-activate.sh
+++ b/pimMe/pim-activate.sh
@@ -18,7 +18,8 @@
 #   1. liste des rôles Azure éligibles (scope racine, filtre asTarget) ;
 #   2. sélection au clavier (flèches ou numéro), r rafraîchit, q quitte ;
 #   3. justification saisie à l'écran, obligatoire sur les rôles sensibles ;
-#   4. soumission SelfActivate puis polling du statut jusqu'au provisionnement ;
+#   4. lecture de la durée max dans la policy PIM du rôle, puis soumission
+#      SelfActivate et polling du statut jusqu'au provisionnement ;
 #   5. retour automatique à la liste rafraîchie, quel que soit le résultat.
 #
 # Prérequis :
@@ -49,11 +50,17 @@ set -euo pipefail
 
 SCRIPT_NAME="$(basename "$0")"
 
-# Durée d'activation demandée (heures). L'API d'éligibilité n'expose pas le
-# maximum autorisé par la politique PIM : la valeur est envoyée telle quelle et
-# un refus de la politique est diagnostiqué par explain_az_error.
-# Voir plan.md — hypothèse à ajuster selon le tenant.
-DEFAULT_DURATION_HOURS=8
+# Durée de repli (heures), utilisée uniquement quand la policy PIM du rôle est
+# illisible (appel en échec, réponse inattendue). Volontairement basse : mieux
+# vaut une activation courte qu'un refus de la politique. La durée nominale est
+# lue par activation dans la policy du rôle (cf. resolve_activation_duration).
+FALLBACK_DURATION_HOURS=1
+
+# Durée ISO 8601 retenue pour l'activation en cours (ex. PT8H, P1D). Renseignée
+# par resolve_activation_duration juste avant la soumission, et consommée par le
+# corps de requête puis par le message de succès.
+ACTIVATION_DURATION=""
+
 
 MENU_HINT="Flèches haut/bas + Entrée, numéro + Entrée, q pour annuler : "
 
@@ -131,8 +138,12 @@ Exemples:
   # Afficher cette aide
   $SCRIPT_NAME --help
 
-Durée d'activation demandée : ${DEFAULT_DURATION_HOURS}h (constante DEFAULT_DURATION_HOURS
-en tête de script).
+Durée d'activation:
+  La durée maximale autorisée est propre à chaque rôle et à chaque scope. Elle
+  est lue dans la policy PIM du rôle sélectionné (règle
+  Expiration_EndUser_Assignment) juste avant la soumission, et affichée. Si
+  cette lecture échoue, le script se replie sur ${FALLBACK_DURATION_HOURS}h
+  (constante FALLBACK_DURATION_HOURS) plutôt que d'abandonner l'activation.
 EOF
 }
 
@@ -747,9 +758,11 @@ explain_az_error() {
             err "Ce rôle est déjà actif (ou une demande est déjà en cours) sur ce scope."
             err "Attendez son expiration ou désactivez-le dans le portail PIM."
             ;;
-        *RoleAssignmentRequestPolicyValidationFailed*|*MaximumDuration*|*maximum*duration*)
-            err "Durée demandée refusée par la politique PIM du rôle."
-            err "Baissez DEFAULT_DURATION_HOURS (actuellement ${DEFAULT_DURATION_HOURS}h) en tête de script."
+        *RoleAssignmentRequestPolicyValidationFailed*|*MaximumDuration*|*maximum*duration*|*ExpirationRule*)
+            err "Durée refusée par la politique PIM du rôle (${ACTIVATION_DURATION:-inconnue} demandée)."
+            err "La durée a pourtant été lue dans la policy du rôle : la règle a pu"
+            err "changer entre-temps, ou l'activation exige une date de fin explicite."
+            err "Vérifiez la règle Expiration_EndUser_Assignment du rôle dans le portail."
             ;;
         *"Connection aborted"*|*"Max retries exceeded"*|*"Failed to establish a new connection"*|\
         *"Name or service not known"*|*"Temporary failure in name resolution"*|\
@@ -903,6 +916,77 @@ iso_utc_now() {
     date -u +%Y-%m-%dT%H:%M:%SZ
 }
 
+# ---------------------------------------------------------------------------
+# Durée d'activation : lecture de la policy PIM du rôle
+#
+# La durée maximale n'est pas portée par l'éligibilité mais par la policy du
+# rôle, qui dépend du couple (scope, roleDefinitionId) : une constante globale
+# se fait refuser dès qu'un rôle est plus restrictif que les autres
+# (RoleAssignmentRequestPolicyValidationFailed sur l'ExpirationRule).
+#
+# La règle qui gouverne une auto-activation est Expiration_EndUser_Assignment ;
+# les règles Expiration_Admin_* concernent l'attribution par un administrateur
+# et ne s'appliquent pas ici.
+# ---------------------------------------------------------------------------
+
+# Rend une durée ISO 8601 lisible (PT8H -> « 8 h », P1D -> « 1 j »). Une forme
+# inattendue est rendue telle quelle : mieux vaut afficher PT45S que mentir.
+humanize_duration() {
+    local iso="$1" out="" days hours minutes
+
+    [[ "$iso" =~ ^P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?)?$ ]] || { printf '%s' "$iso"; return 0; }
+    days="${BASH_REMATCH[1]%D}"
+    hours="${BASH_REMATCH[3]%H}"
+    minutes="${BASH_REMATCH[4]%M}"
+    [[ -n "$days" ]] && out+="${days} j "
+    [[ -n "$hours" ]] && out+="${hours} h "
+    [[ -n "$minutes" ]] && out+="${minutes} min "
+    out="${out% }"
+    printf '%s' "${out:-$iso}"
+}
+
+# Extrait la durée max d'auto-activation d'une réponse roleManagementPolicy-
+# Assignments. Vide si la règle est absente ou la réponse inattendue.
+_max_duration_from_policy() {
+    jq -r '
+        [ .value[]?.properties.effectiveRules[]?
+          | select(.id == "Expiration_EndUser_Assignment")
+          | .maximumDuration // empty ]
+        | first // empty
+    ' 2>/dev/null
+}
+
+# Renseigne $ACTIVATION_DURATION pour le rôle $1 et affiche la durée retenue.
+# Un seul appel de policy par activation. Ne rend jamais la main en échec : une
+# policy illisible se replie sur FALLBACK_DURATION_HOURS, l'activation courte
+# valant mieux qu'un abandon.
+resolve_activation_duration() {
+    local index="$1" url body duration=""
+
+    # $filter encodé (%24, %20, %27) : l'URL part telle quelle dans az rest, où
+    # un $ nu serait mangé par le shell et une apostrophe nue par l'API.
+    url="https://management.azure.com${ROLE_SCOPES[$index]}/providers/Microsoft.Authorization/roleManagementPolicyAssignments?api-version=${ARM_API_VERSION}&%24filter=roleDefinitionId%20eq%20%27${ROLE_DEFINITION_IDS[$index]}%27"
+
+    if body="$(az_rest_get "$url")"; then
+        duration="$(_max_duration_from_policy <<<"$body")"
+    fi
+
+    if [[ "$duration" =~ ^P([0-9]+D)?(T([0-9]+H)?([0-9]+M)?)?$ && "$duration" != "P" ]]; then
+        ACTIVATION_DURATION="$duration"
+        info "Durée retenue : $(humanize_duration "$duration") (policy du rôle, maximumDuration ${duration})."
+        return 0
+    fi
+
+    ACTIVATION_DURATION="PT${FALLBACK_DURATION_HOURS}H"
+    if [[ -n "$duration" ]]; then
+        info "Durée de policy inexploitable ('${duration}')."
+    else
+        info "Policy PIM du rôle illisible : $(az_rest_last_error | head -1)"
+    fi
+    info "Durée retenue : $(humanize_duration "$ACTIVATION_DURATION") (repli FALLBACK_DURATION_HOURS)."
+    return 0
+}
+
 # Appel avec corps JSON, même gestion d'erreur que az_rest_get.
 az_rest_send() {
     local method="$1" url="$2" body="$3" out rc=0
@@ -925,7 +1009,7 @@ _azure_activation_body() {
         --arg roleDefinitionId "${ROLE_DEFINITION_IDS[$index]}" \
         --arg justification "$JUSTIFICATION" \
         --arg start "$(iso_utc_now)" \
-        --arg duration "PT${DEFAULT_DURATION_HOURS}H" \
+        --arg duration "$ACTIVATION_DURATION" \
         --arg linked "$linked" \
         '{properties: ({
             principalId: $principalId,
@@ -1000,7 +1084,7 @@ poll_activation() {
             case "$status" in
                 Provisioned|Granted)
                     printf '\n' >&2
-                    info "Rôle activé (${status}) pour ${DEFAULT_DURATION_HOURS}h."
+                    info "Rôle activé (${status}) pour $(humanize_duration "$ACTIVATION_DURATION")."
                     return 0
                     ;;
                 Failed|Denied|Revoked|Cancelled|Canceled)
@@ -1056,7 +1140,16 @@ activate_role() {
     fi
 
     info ""
-    info "Soumission de la demande (${DEFAULT_DURATION_HOURS}h)…"
+    resolve_activation_duration "$index"
+
+    # Un Ctrl+C pendant l'appel de policy ne doit pas se solder par une
+    # soumission surprise : on s'arrête avant, comme pour la justification.
+    if take_interrupt; then
+        info "Activation abandonnée avant soumission."
+        return 0
+    fi
+
+    info "Soumission de la demande ($(humanize_duration "$ACTIVATION_DURATION"))…"
     rc=0
     submit_azure_activation "$index" || rc=$?
     if (( rc != 0 )); then

--- a/pimMe/tests/test_activation.sh
+++ b/pimMe/tests/test_activation.sh
@@ -239,17 +239,27 @@ diagnose() {
     printf '%s\n' "$1" > "$AZ_REST_ERROR_FILE"
     explain_az_error 2>&1
 }
-check "consentement Graph manquant" "ok" "$(diagnose 'ERROR: PermissionScopeNotGranted' | grep -q 'permissions Graph' && echo ok || echo ko)"
-check "session expirée (AADSTS70043)" "ok" "$(diagnose 'SubError: token_expired AADSTS70043: refresh token expired' | grep -q 'Session Azure CLI expirée' && echo ok || echo ko)"
-check "rappel du tenant dans az login" "ok" "$(diagnose 'AADSTS70043' | grep -q "$AZ_TENANT_ID" && echo ok || echo ko)"
-check "MFA requis"                  "ok" "$(diagnose 'AADSTS50076: due to a configuration change made by your administrator' | grep -q 'authentification forte' && echo ok || echo ko)"
-check "rôle déjà actif"             "ok" "$(diagnose 'ERROR: Bad Request({"error":{"code":"RoleAssignmentExists","message":"The Role assignment already exists."}})' | grep -q 'déjà actif' && echo ok || echo ko)"
-check "durée refusée par la politique" "ok" "$(diagnose 'RoleAssignmentRequestPolicyValidationFailed' | grep -q 'Expiration_EndUser_Assignment' && echo ok || echo ko)"
-check "durée demandée rappelée"     "ok" "$(diagnose 'ExpirationRule' | grep -q 'PT4H' && echo ok || echo ko)"
-check "détail brut toujours affiché" "ok" "$(diagnose 'Erreur inconnue XYZ' | grep -q 'Erreur inconnue XYZ' && echo ok || echo ko)"
+
+# `diagnose … | grep -q` est une course perdue d'avance : grep -q sort dès la
+# ligne qui correspond, explain_az_error prend un SIGPIPE sur la ligne suivante
+# et pipefail transforme le succès en échec, au hasard du timing. On matérialise
+# donc la sortie avant de la filtrer.
+diag_has() {
+    local out
+    out="$(diagnose "$1")"
+    grep -q "$2" <<<"$out" && echo ok || echo ko
+}
+check "consentement Graph manquant" "ok" "$(diag_has 'ERROR: PermissionScopeNotGranted' 'permissions Graph')"
+check "session expirée (AADSTS70043)" "ok" "$(diag_has 'SubError: token_expired AADSTS70043: refresh token expired' 'Session Azure CLI expirée')"
+check "rappel du tenant dans az login" "ok" "$(diag_has 'AADSTS70043' "$AZ_TENANT_ID")"
+check "MFA requis"                  "ok" "$(diag_has 'AADSTS50076: due to a configuration change made by your administrator' 'authentification forte')"
+check "rôle déjà actif"             "ok" "$(diag_has 'ERROR: Bad Request({"error":{"code":"RoleAssignmentExists","message":"The Role assignment already exists."}})' 'déjà actif')"
+check "durée refusée par la politique" "ok" "$(diag_has 'RoleAssignmentRequestPolicyValidationFailed' 'Expiration_EndUser_Assignment')"
+check "durée demandée rappelée"     "ok" "$(diag_has 'ExpirationRule' 'PT4H')"
+check "détail brut toujours affiché" "ok" "$(diag_has 'Erreur inconnue XYZ' 'Erreur inconnue XYZ')"
 # Panne réseau : le message doit rester lisible et parler connectivité.
-check "réseau injoignable (DNS)"    "ok" "$(diagnose "urllib3 ... Failed to establish a new connection: [Errno -3] Temporary failure in name resolution" | grep -q 'réseau ou le service ne répond pas' && echo ok || echo ko)"
-check "réseau injoignable (timeout)" "ok" "$(diagnose 'HTTPSConnectionPool(host=management.azure.com): Read timed out. (read timeout=300)' | grep -q 'réseau ou le service ne répond pas' && echo ok || echo ko)"
+check "réseau injoignable (DNS)"    "ok" "$(diag_has "urllib3 ... Failed to establish a new connection: [Errno -3] Temporary failure in name resolution" 'réseau ou le service ne répond pas')"
+check "réseau injoignable (timeout)" "ok" "$(diag_has 'HTTPSConnectionPool(host=management.azure.com): Read timed out. (read timeout=300)' 'réseau ou le service ne répond pas')"
 
 printf '\n'
 if (( fails == 0 )); then

--- a/pimMe/tests/test_activation.sh
+++ b/pimMe/tests/test_activation.sh
@@ -58,6 +58,7 @@ ROLE_NAMES=("Owner" "User Access Administrator" "Reader")
 AZ_PRINCIPAL_ID="11111111-2222-3333-4444-555555555555"
 # Volontairement piégeuse : guillemets, apostrophe, accents, backslash.
 JUSTIFICATION='Incident "P1" — l'"'"'accès prod\test'
+ACTIVATION_DURATION="PT4H"
 
 printf '=== Corps de requête Azure (ARM) ===\n'
 
@@ -68,7 +69,7 @@ check "principalId = utilisateur"         "$AZ_PRINCIPAL_ID" "$(jq -r '.properti
 check "roleDefinitionId"                  "${ROLE_DEFINITION_IDS[0]}" "$(jq -r '.properties.roleDefinitionId' <<<"$body")"
 check "justification échappée telle quelle" "$JUSTIFICATION" "$(jq -r '.properties.justification' <<<"$body")"
 check "expiration.type"                   "AfterDuration" "$(jq -r '.properties.scheduleInfo.expiration.type' <<<"$body")"
-check "duration = DEFAULT_DURATION_HOURS" "PT${DEFAULT_DURATION_HOURS}H" "$(jq -r '.properties.scheduleInfo.expiration.duration' <<<"$body")"
+check "duration = durée résolue"          "$ACTIVATION_DURATION" "$(jq -r '.properties.scheduleInfo.expiration.duration' <<<"$body")"
 check "startDateTime au format ISO UTC"   "ok" "$(jq -r '.properties.scheduleInfo.startDateTime' <<<"$body" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' && echo ok || echo ko)"
 check "linked absent par défaut"          "null" "$(jq -r '.properties.linkedRoleEligibilityScheduleId // "null"' <<<"$body")"
 
@@ -202,6 +203,32 @@ check "aucune URL Graph dans le script" "0" \
 check "aucune soumission Entra"     "ko" \
     "$(declare -f submit_entra_activation >/dev/null 2>&1 && echo ok || echo ko)"
 
+printf '\n=== Durée lue dans la policy PIM ===\n'
+
+# Réponse réelle abrégée : les trois règles d'expiration cohabitent, seule
+# Expiration_EndUser_Assignment gouverne une auto-activation.
+policy_json() {
+    cat <<'JSON'
+{"value":[{"properties":{"effectiveRules":[
+  {"id":"Expiration_Admin_Eligibility","ruleType":"RoleManagementPolicyExpirationRule","maximumDuration":"P365D"},
+  {"id":"Expiration_Admin_Assignment","ruleType":"RoleManagementPolicyExpirationRule","maximumDuration":"P180D"},
+  {"id":"Expiration_EndUser_Assignment","ruleType":"RoleManagementPolicyExpirationRule","maximumDuration":"PT8H"}
+]}}]}
+JSON
+}
+
+check "maximumDuration extrait"      "PT8H" "$(policy_json | _max_duration_from_policy)"
+check "règles admin ignorées"        "1"    "$(policy_json | _max_duration_from_policy | grep -c '^PT8H$')"
+check "réponse vide -> rien"         ""     "$(printf '{"value":[]}' | _max_duration_from_policy)"
+check "règle absente -> rien"        ""     "$(printf '{"value":[{"properties":{"effectiveRules":[{"id":"Enablement_EndUser_Assignment"}]}}]}' | _max_duration_from_policy)"
+check "JSON illisible -> rien"       ""     "$(printf 'pas du json' | _max_duration_from_policy)"
+
+check "PT8H lisible"                 "8 h"  "$(humanize_duration PT8H)"
+check "P1D lisible"                  "1 j"  "$(humanize_duration P1D)"
+check "PT1H30M lisible"              "1 h 30 min" "$(humanize_duration PT1H30M)"
+check "PT30M lisible"                "30 min" "$(humanize_duration PT30M)"
+check "forme inattendue rendue telle quelle" "PT45S" "$(humanize_duration PT45S)"
+
 printf '\n=== Diagnostic des erreurs az ===\n'
 
 AZ_REST_ERROR_FILE="$(mktemp)"
@@ -217,7 +244,8 @@ check "session expirée (AADSTS70043)" "ok" "$(diagnose 'SubError: token_expired
 check "rappel du tenant dans az login" "ok" "$(diagnose 'AADSTS70043' | grep -q "$AZ_TENANT_ID" && echo ok || echo ko)"
 check "MFA requis"                  "ok" "$(diagnose 'AADSTS50076: due to a configuration change made by your administrator' | grep -q 'authentification forte' && echo ok || echo ko)"
 check "rôle déjà actif"             "ok" "$(diagnose 'ERROR: Bad Request({"error":{"code":"RoleAssignmentExists","message":"The Role assignment already exists."}})' | grep -q 'déjà actif' && echo ok || echo ko)"
-check "durée refusée par la politique" "ok" "$(diagnose 'RoleAssignmentRequestPolicyValidationFailed' | grep -q 'DEFAULT_DURATION_HOURS' && echo ok || echo ko)"
+check "durée refusée par la politique" "ok" "$(diagnose 'RoleAssignmentRequestPolicyValidationFailed' | grep -q 'Expiration_EndUser_Assignment' && echo ok || echo ko)"
+check "durée demandée rappelée"     "ok" "$(diagnose 'ExpirationRule' | grep -q 'PT4H' && echo ok || echo ko)"
 check "détail brut toujours affiché" "ok" "$(diagnose 'Erreur inconnue XYZ' | grep -q 'Erreur inconnue XYZ' && echo ok || echo ko)"
 # Panne réseau : le message doit rester lisible et parler connectivité.
 check "réseau injoignable (DNS)"    "ok" "$(diagnose "urllib3 ... Failed to establish a new connection: [Errno -3] Temporary failure in name resolution" | grep -q 'réseau ou le service ne répond pas' && echo ok || echo ko)"


### PR DESCRIPTION
## Résumé
- `feat(pimMe)!` — la durée d'activation est lue dans la policy PIM du rôle (règle `Expiration_EndUser_Assignment` de `roleManagementPolicyAssignments`, filtrée sur le scope et la roleDefinitionId), affichée avant soumission, avec repli sur `FALLBACK_DURATION_HOURS=1` si la lecture échoue. `DEFAULT_DURATION_HOURS` disparaît. **BREAKING CHANGE** : la durée soumise varie désormais par rôle au lieu d'être toujours 8h.
- `test(pimMe)` — correctif d'une flakiness antérieure : `diagnose … | grep -q` faisait prendre un SIGPIPE à `explain_az_error`, que `pipefail` transformait en échec ~1 run sur 3.

## Vérification sur tenant réel
| Rôle | Durée lue | Statut |
|------|-----------|--------|
| Contributor — subscription SandBox | 8 h (PT8H) | Provisioned |
| Owner — subscription SandBox | 8 h (PT8H) | Provisioned |
| Contributor — managementgroup MG-Brucity | 4 h (PT4H) | Provisioned |

Le balayage des 19 rôles éligibles donne PT4H / PT8H / PT9H selon le couple (scope, rôle) : les quatre rôles à PT4H sont exactement ceux que l'ancienne constante à 8h faisait refuser.

## Revue
- [ ] Changements validés
- [ ] Tests passent (`test_activation.sh`, `test_menu.sh`, `test_interrupt.sh` — les trois vertes)

🤖 Co-created with [Claude Code](https://claude.ai/code)